### PR TITLE
export all imported module declarations

### DIFF
--- a/src/packages/piral-cli/src/common/decl.ts
+++ b/src/packages/piral-cli/src/common/decl.ts
@@ -45,9 +45,10 @@ export function combineApiDeclarations(root: string, dependencyNames: Array<stri
   }
 
   const imports = paths.map(path => `import '${path}';`).join('\n');
+  const exports = paths.map(path => `export * from '${path}';`).join('\n');
   return `${imports}
 
-export * from 'piral-core/api';`;
+${exports}`;
 }
 
 function isContainedPackage(name: string) {


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

### Description

As said in #116, we need type exports for things we export from the package. This change exports all module declarations that have been imported into the shell module declaration (top module declaration in `package/app/index.d.ts`).

### Remarks

This only partially solves #116, but it adds a crucial part needed for us to migrate to 0.9.x