### PR TITLE
Providing ability to supply custom fetcher via PiralRenderOptions con…

### DIFF
--- a/src/packages/piral-core/src/createInstance.tsx
+++ b/src/packages/piral-core/src/createInstance.tsx
@@ -32,6 +32,7 @@ export function createInstance(config: PiralConfiguration = {}): PiralInstance {
     availablePilets = [],
     extendApi = [],
     requestPilets = defaultModuleRequester,
+    fetchDependency,
     getDependencies = getLocalDependencies,
     async = false,
   } = config;
@@ -48,6 +49,7 @@ export function createInstance(config: PiralConfiguration = {}): PiralInstance {
     context,
     createApi,
     availablePilets,
+    fetchDependency,
     getDependencies,
     strategy: isfunc(async) ? async : async ? blazingStrategy : standardStrategy,
     requestPilets,

--- a/src/packages/piral-core/src/helpers.tsx
+++ b/src/packages/piral-core/src/helpers.tsx
@@ -1,5 +1,5 @@
 import { addChangeHandler } from '@dbeining/react-atom';
-import { PiletApiCreator, LoadPiletsOptions, getDependencyResolver, loadPilet } from 'piral-base';
+import { PiletApiCreator, LoadPiletsOptions, PiletDependencyFetcher, getDependencyResolver, loadPilet } from 'piral-base';
 import { globalDependencies, getLocalDependencies } from './modules';
 import {
   AvailableDependencies,
@@ -39,6 +39,7 @@ export function extendSharedDependencies(additionalDependencies: AvailableDepend
 interface PiletOptionsConfig {
   availablePilets: Array<Pilet>;
   createApi: PiletApiCreator;
+  fetchDependency: PiletDependencyFetcher;
   getDependencies: PiletDependencyGetter;
   strategy: PiletLoadingStrategy;
   requestPilets: PiletRequester;
@@ -49,6 +50,7 @@ export function createPiletOptions({
   context,
   createApi,
   availablePilets,
+  fetchDependency,
   getDependencies,
   strategy,
   requestPilets,
@@ -113,6 +115,7 @@ export function createPiletOptions({
 
   return {
     pilets: availablePilets,
+    fetchDependency,
     getDependencies,
     strategy,
     dependencies: globalDependencies,

--- a/src/packages/piral-core/src/types/config.ts
+++ b/src/packages/piral-core/src/types/config.ts
@@ -1,9 +1,9 @@
-import { PiletRequester, PiletDependencyGetter, PiletLoadingStrategy, Pilet, AvailableDependencies } from 'piral-base';
+import { PiletRequester, PiletDependencyFetcher, PiletDependencyGetter, PiletLoadingStrategy, Pilet, AvailableDependencies } from 'piral-base';
 import { NestedPartial } from './common';
 import { Extend } from './plugin';
 import { GlobalState, PiralDefineActions } from './state';
 
-export { PiletLoadingStrategy, PiletDependencyGetter, PiletRequester, AvailableDependencies };
+export { PiletLoadingStrategy, PiletDependencyFetcher, PiletDependencyGetter, PiletRequester, AvailableDependencies };
 
 export interface PiralPiletConfiguration {
   /*
@@ -24,6 +24,10 @@ export interface PiralPiletConfiguration {
 }
 
 export interface PiralStateConfiguration {
+  /**
+   * The callback for defining how a dependency will be fetched.
+   */
+  fetchDependency?: PiletDependencyFetcher;
   /**
    * Function to get the dependencies for a given module.
    */


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

### Description

Providing ability to supply custom fetcher via PiralRenderOptions configuration, which seems to have been designed for this capacity but was accidentally missed it out.

### Remarks

PiralRenderOptions was already able to accept "fetchDependency" via its parameters, but then it was nowhere used and lost along the way before it gets passed to creation of PiletOptionsConfig (by calling createPilotOptions() in createInstance.tsx) which is the one controlling which fetcher to use, and always took a default without ability to override. 
