### PR TITLE
Cannot set property 'verbose' of undefined

### DIFF
--- a/src/packages/piral-cli/src/common/log.ts
+++ b/src/packages/piral-cli/src/common/log.ts
@@ -13,7 +13,7 @@ type MessageTypes = keyof Messages;
 if (isWindows) {
   const stripAnsi = require('strip-ansi');
 
-  logger.prototype.verbose = function(message: string) {
+  logger.verbose = function(message: string) {
     if (this.logLevel < 4) {
       return;
     }


### PR DESCRIPTION
System: window
@parcel/logger Version: 1.11.1
debug the code, `logger.prototype` is undefuned

# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [ ] I have read the **CONTRIBUTING** document
- [ ] My code follows the code style of this project
- [ ] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

### Description

[Place a meaningful description here]

### Remarks

[Optionally place any follow-up comments, remarks, observations, or notes here for future reference]
