### PR TITLE
Fixed sourcemaps for pilets

### DIFF
--- a/src/packages/piral-base/src/dependency.ts
+++ b/src/packages/piral-base/src/dependency.ts
@@ -50,7 +50,7 @@ export function evalDependency(name: string, content: string, link = '', depende
 
   try {
     const sourceUrl = link && `\n//# sourceURL=${link}`;
-    const importer = new Function('module', 'exports', 'require', content + sourceUrl);
+    const importer = eval('(function anonymous(module,exports,require) {' + content + sourceUrl + '\n});\n');
     importer(mod, mod.exports, require);
   } catch (e) {
     console.error(`Error while evaluating ${name}.`, e);

--- a/src/packages/piral-cli/src/parcel/bundler.test.ts
+++ b/src/packages/piral-cli/src/parcel/bundler.test.ts
@@ -66,8 +66,7 @@ describe('Pilet Build Module', () => {
       PiletSchemaVersion.directEval,
     );
     expect(writeContent)
-      .toBe(`//@pilet v:0\n!(function(global,parcelRequire){'use strict';var __bundleUrl__=function(){try{throw new Error}catch(t){const e=(\"\"+t.stack).match(/(https?|file|ftp|chrome-extension|moz-extension):\\/\\/[^)\\n]+/g);if(e)return e[0].replace(/^((?:https?|file|ftp|chrome-extension|moz-extension):\\/\\/.+)\\/[^\\/]+$/,\"$1\")+\"/\"}return\"/\"}();
-no-js
+      .toBe(`/*@pilet v:0*/ !(function(global,parcelRequire){'use strict';var __bundleUrl__=function(){try{throw new Error}catch(t){const e=(\"\"+t.stack).match(/(https?|file|ftp|chrome-extension|moz-extension):\\/\\/[^)\\n]+/g);if(e)return e[0].replace(/^((?:https?|file|ftp|chrome-extension|moz-extension):\\/\\/.+)\\/[^\\/]+$/,\"$1\")+\"/\"}return\"/\"}();;no-js
 ;global.pr_abcdef=parcelRequire}(window, window.pr_abcdef));`);
   });
 
@@ -85,8 +84,7 @@ no-js
       PiletSchemaVersion.currentScript,
     );
     expect(writeContent)
-      .toBe(`//@pilet v:1(pr_abcdef)\n!(function(global,parcelRequire){'use strict';var __bundleUrl__=function(){try{throw new Error}catch(t){const e=(\"\"+t.stack).match(/(https?|file|ftp|chrome-extension|moz-extension):\\/\\/[^)\\n]+/g);if(e)return e[0].replace(/^((?:https?|file|ftp|chrome-extension|moz-extension):\\/\\/.+)\\/[^\\/]+$/,\"$1\")+\"/\"}return\"/\"}();function define(getExports){(typeof document!=='undefined')&&(document.currentScript.app=getExports())};define.amd=true;
-no-js
+      .toBe(`/*@pilet v:1(pr_abcdef)*/ !(function(global,parcelRequire){'use strict';var __bundleUrl__=function(){try{throw new Error}catch(t){const e=(\"\"+t.stack).match(/(https?|file|ftp|chrome-extension|moz-extension):\\/\\/[^)\\n]+/g);if(e)return e[0].replace(/^((?:https?|file|ftp|chrome-extension|moz-extension):\\/\\/.+)\\/[^\\/]+$/,\"$1\")+\"/\"}return\"/\"}();function define(getExports){(typeof document!=='undefined')&&(document.currentScript.app=getExports())};define.amd=true;;no-js
 ;global.pr_abcdef=parcelRequire}(window, window.pr_abcdef));`);
   });
 });


### PR DESCRIPTION
Omitting any extra newlines in the pilet's preamble to maintain the validity of original Parcel sourcemaps.

The postprocessing of the bundling action and also the loading (via "new Function()") of pilets itself was producing extra newlines in the beginning of the generated code. This was causing a mismatch against sourcemaps that were produced earlier by Parcel. Therefore extra generated code is added to the bundle by using semicolons (instead of newlines) as a separator now.

# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

### Description

[Place a meaningful description here]

### Remarks

[Optionally place any follow-up comments, remarks, observations, or notes here for future reference]
