### PR TITLE
Feature/#219 piral oidc redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added tutorial for the migration of existing applications (#180)
 * Added `piral-cli-parcel` plugin for Parcel integration (#125)
 * Fixed the source map offset in Parcel (#216)
+* Added `handleAuthentication` to piral-oidc (#219)
 
 ## 0.11.4 (May 6, 2020)
 

--- a/src/packages/piral-oidc/src/OidcError.ts
+++ b/src/packages/piral-oidc/src/OidcError.ts
@@ -1,0 +1,37 @@
+import { OidcErrorType, PiralOidcError } from './types';
+
+const errorMessageMap = {
+  [OidcErrorType.notAuthorized]: 'Not logged in. Please call `login()` to retrieve a token.',
+  [OidcErrorType.silentRenewFailed]: 'Silent renew failed to retrieve access token.',
+  [OidcErrorType.invalidToken]: 'Invalid token during authentication',
+};
+
+const getErrorMessage = (type: OidcErrorType, innerError?: Error | string) => {
+  const message = errorMessageMap[type];
+  return message || (innerError ? innerError.toString() : 'an unexpected error has occurred without a message');
+};
+
+/**
+ * A custom error class for oidc errors. It is important to use this class
+ * instead of generic Errors, as some application paths inspect `OidcError['type']`.
+ *
+ * An optional innerError can be supplied in order to not lose visibility on messages provided
+ * by oidc-client.
+ */
+export class OidcError extends Error implements PiralOidcError {
+  public readonly type;
+  public readonly innerError;
+
+  constructor(errorType: OidcErrorType, innerError?: Error | string) {
+    const message = getErrorMessage(errorType, innerError);
+    super(message);
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, OidcError);
+    }
+
+    this.name = 'OidcError';
+    this.type = errorType;
+    this.innerError = innerError;
+  }
+}

--- a/src/packages/piral-oidc/src/setup.test.ts
+++ b/src/packages/piral-oidc/src/setup.test.ts
@@ -18,42 +18,15 @@ describe('Piral-Oidc setup module', () => {
     access_token: '123',
     expires_in: 100,
   };
-  const mockGetUser = jest
-    .fn()
-    .mockResolvedValue(user)
-    .mockName('getUser');
-  const mockSigninCallback = jest
-    .fn()
-    .mockResolvedValue(undefined)
-    .mockName('signinCallback');
-  const mockSigninRedirectCallback = jest
-    .fn()
-    .mockResolvedValue(undefined)
-    .mockName('signinRedirectCallback');
-  const mockSigninRedirect = jest
-    .fn()
-    .mockResolvedValue(undefined)
-    .mockName('signinRedirect');
-  const mockSigninSilent = jest
-    .fn()
-    .mockResolvedValue(undefined)
-    .mockName('signinSilent');
-  const mockSigninSilentCallback = jest
-    .fn()
-    .mockResolvedValue(undefined)
-    .mockName('signinSilentCallback');
-  const mockSignoutRedirect = jest
-    .fn()
-    .mockResolvedValue(undefined)
-    .mockName('signoutRedirect');
-  const mockSignoutRedirectCallback = jest
-    .fn()
-    .mockResolvedValue(undefined)
-    .mockName('signoutRedirectCallback');
-  const mockSignoutPopupCallback = jest
-    .fn()
-    .mockResolvedValue(undefined)
-    .mockName('signoutPopupCallback');
+  const mockGetUser = jest.fn().mockResolvedValue(user).mockName('getUser');
+  const mockSigninCallback = jest.fn().mockResolvedValue(undefined).mockName('signinCallback');
+  const mockSigninRedirectCallback = jest.fn().mockResolvedValue(undefined).mockName('signinRedirectCallback');
+  const mockSigninRedirect = jest.fn().mockResolvedValue(undefined).mockName('signinRedirect');
+  const mockSigninSilent = jest.fn().mockResolvedValue(undefined).mockName('signinSilent');
+  const mockSigninSilentCallback = jest.fn().mockResolvedValue(undefined).mockName('signinSilentCallback');
+  const mockSignoutRedirect = jest.fn().mockResolvedValue(undefined).mockName('signoutRedirect');
+  const mockSignoutRedirectCallback = jest.fn().mockResolvedValue(undefined).mockName('signoutRedirectCallback');
+  const mockSignoutPopupCallback = jest.fn().mockResolvedValue(undefined).mockName('signoutPopupCallback');
 
   const mockEvents: UserManagerEvents = {} as any;
 
@@ -63,7 +36,7 @@ describe('Piral-Oidc setup module', () => {
 
   beforeAll(() => {
     //@ts-ignore
-    MockUserManager.mockImplementation(settings => {
+    MockUserManager.mockImplementation((settings) => {
       return {
         getUser: mockGetUser,
         events: mockEvents,

--- a/src/packages/piral-oidc/src/setup.test.ts
+++ b/src/packages/piral-oidc/src/setup.test.ts
@@ -172,10 +172,10 @@ describe('Piral-Oidc setup module', () => {
     });
 
     it('token() should reject when a user does not have an access_token', () => {
-        mockGetUser.mockResolvedValue({});
-        mockSigninSilent.mockResolvedValue({});
-        return expect(client.token()).rejects.toHaveProperty('type', OidcErrorType.invalidToken);
-    })
+      mockGetUser.mockResolvedValue({});
+      mockSigninSilent.mockResolvedValue({});
+      return expect(client.token()).rejects.toHaveProperty('type', OidcErrorType.invalidToken);
+    });
 
     it('account() should return the User profile', () => {
       const user: any = {

--- a/src/packages/piral-oidc/src/setup.test.ts
+++ b/src/packages/piral-oidc/src/setup.test.ts
@@ -1,4 +1,4 @@
-import { UserManager, UserManagerEvents } from 'oidc-client';
+import { UserManager } from 'oidc-client';
 
 import { setupOidcClient } from './setup';
 import { OidcClient, OidcConfig, OidcErrorType } from './types';
@@ -11,7 +11,6 @@ describe('Piral-Oidc setup module', () => {
   const setWindowInTop = () =>
     Object.defineProperty(window, 'top', { value: window, configurable: true, writable: true });
   const originalWindowLocation = window.location;
-  const retrieveTokenErrMessage = 'Silent renew failed to retrieve access token';
   let oidcConfig: OidcConfig;
   const MockUserManager = UserManager as jest.MockedClass<typeof UserManager>;
   const user = {
@@ -28,8 +27,6 @@ describe('Piral-Oidc setup module', () => {
   const mockSignoutRedirectCallback = jest.fn().mockResolvedValue(undefined).mockName('signoutRedirectCallback');
   const mockSignoutPopupCallback = jest.fn().mockResolvedValue(undefined).mockName('signoutPopupCallback');
 
-  const mockEvents: UserManagerEvents = {} as any;
-
   const postLogoutRedirectUri = 'http://localhost:8000/post-logout';
   const redirectUri = 'http://localhost:8000/callback';
   const appUri = 'http://localhost:8000/app';
@@ -39,7 +36,6 @@ describe('Piral-Oidc setup module', () => {
     MockUserManager.mockImplementation((settings) => {
       return {
         getUser: mockGetUser,
-        events: mockEvents,
         settings: {
           popup_redirect_uri: settings.popup_redirect_uri || settings.redirect_uri,
           post_logout_redirect_uri: settings.post_logout_redirect_uri,
@@ -91,7 +87,6 @@ describe('Piral-Oidc setup module', () => {
         extendHeaders: expect.any(Function),
         token: expect.any(Function),
         account: expect.any(Function),
-        events: mockEvents,
         handleAuthentication: expect.any(Function),
       });
     });

--- a/src/packages/piral-oidc/src/setup.test.ts
+++ b/src/packages/piral-oidc/src/setup.test.ts
@@ -1,82 +1,177 @@
-import { UserManager } from 'oidc-client';
+import { UserManager, UserManagerEvents } from 'oidc-client';
 
-import { setupOidcClient } from './setup';
+import { setupOidcClient, notLoggedInMessage } from './setup';
 import { OidcClient, OidcConfig } from './types';
 
 jest.mock('oidc-client');
 
 describe('Piral-Oidc setup module', () => {
+  const setWindowInIFrame = () =>
+    Object.defineProperty(window, 'top', { value: { ...window }, configurable: true, writable: true });
+  const setWindowInTop = () =>
+    Object.defineProperty(window, 'top', { value: window, configurable: true, writable: true });
+  const originalWindowLocation = window.location;
+  const retrieveTokenErrMessage = 'Silent renew failed to retrieve access token';
   let oidcConfig: OidcConfig;
   const MockUserManager = UserManager as jest.MockedClass<typeof UserManager>;
+  const user = {
+    access_token: '123',
+    expires_in: 100,
+  };
+  const mockGetUser = jest
+    .fn()
+    .mockResolvedValue(user)
+    .mockName('getUser');
+  const mockSigninCallback = jest
+    .fn()
+    .mockResolvedValue(undefined)
+    .mockName('signinCallback');
+  const mockSigninRedirectCallback = jest
+    .fn()
+    .mockResolvedValue(undefined)
+    .mockName('signinRedirectCallback');
+  const mockSigninRedirect = jest
+    .fn()
+    .mockResolvedValue(undefined)
+    .mockName('signinRedirect');
+  const mockSigninSilent = jest
+    .fn()
+    .mockResolvedValue(undefined)
+    .mockName('signinSilent');
+  const mockSigninSilentCallback = jest
+    .fn()
+    .mockResolvedValue(undefined)
+    .mockName('signinSilentCallback');
+  const mockSignoutRedirect = jest
+    .fn()
+    .mockResolvedValue(undefined)
+    .mockName('signoutRedirect');
+  const mockSignoutRedirectCallback = jest
+    .fn()
+    .mockResolvedValue(undefined)
+    .mockName('signoutRedirectCallback');
+  const mockSignoutPopupCallback = jest
+    .fn()
+    .mockResolvedValue(undefined)
+    .mockName('signoutPopupCallback');
 
-  afterAll(() => jest.unmock('oidc-client'));
+  const mockEvents: UserManagerEvents = {} as any;
+
+  const postLogoutRedirectUri = 'http://localhost:8000/post-logout';
+  const redirectUri = 'http://localhost:8000/callback';
+  const appUri = 'http://localhost:8000/app';
+
+  beforeAll(() => {
+    //@ts-ignore
+    MockUserManager.mockImplementation(settings => {
+      return {
+        getUser: mockGetUser,
+        events: mockEvents,
+        settings: {
+          popup_redirect_uri: settings.popup_redirect_uri || settings.redirect_uri,
+          post_logout_redirect_uri: settings.post_logout_redirect_uri,
+          redirect_uri: settings.redirect_uri,
+          silent_redirect_uri: settings.silent_redirect_uri || settings.redirect_uri,
+        },
+        signinCallback: mockSigninCallback,
+        signinRedirectCallback: mockSigninRedirectCallback,
+        signinRedirect: mockSigninRedirect,
+        signinSilent: mockSigninSilent,
+        signinSilentCallback: mockSigninSilentCallback,
+        signoutRedirect: mockSignoutRedirect,
+        signoutRedirectCallback: mockSignoutRedirectCallback,
+        signoutPopupCallback: mockSignoutPopupCallback,
+      };
+    });
+  });
+
+  afterAll(() => {
+    jest.unmock('oidc-client');
+    window.location = originalWindowLocation;
+    setWindowInTop();
+  });
 
   beforeEach(() => {
-    MockUserManager.mockClear();
+    jest.clearAllMocks();
+    mockGetUser.mockResolvedValue(user);
+    delete window.location;
+    //@ts-ignore
+    window.location = new URL('http://localhost:8000/');
+    setWindowInTop();
     oidcConfig = {
       clientId: 'clientId',
       identityProviderUri: 'http://localhost:8080/provider/uri',
-      redirectUri: '/auth',
-      postLogoutRedirectUri: '/post-logout',
+      appUri,
+      redirectUri,
+      postLogoutRedirectUri,
       scopes: ['openid', 'custom'],
       restrict: false,
     };
   });
 
-  it('setupOidcClient should return the following signature', () => {
-    const client = setupOidcClient(oidcConfig);
-    expect(client).toMatchObject<OidcClient>({
-      login: expect.any(Function),
-      logout: expect.any(Function),
-      extendHeaders: expect.any(Function),
-      token: expect.any(Function),
-      account: expect.any(Function),
+  describe('setupOidcClient()', () => {
+    it('setupOidcClient should return the following signature', () => {
+      const client = setupOidcClient(oidcConfig);
+      expect(client).toMatchObject<OidcClient>({
+        login: expect.any(Function),
+        logout: expect.any(Function),
+        extendHeaders: expect.any(Function),
+        token: expect.any(Function),
+        account: expect.any(Function),
+        events: mockEvents,
+        handleAuthentication: expect.any(Function),
+      });
     });
-  });
 
-  it('setupOidcClient should do silent redirect', () => {
-    expect(UserManager).not.toHaveBeenCalled();
-    const client = setupOidcClient(oidcConfig);
-    expect(UserManager).toHaveBeenCalledTimes(1);
-    const instance = MockUserManager.mock.instances[0];
-    expect(instance.signinRedirectCallback).toHaveBeenCalledTimes(1);
-    expect(instance.signinSilentCallback).toHaveBeenCalledTimes(1);
-    expect(instance.signoutRedirectCallback).toHaveBeenCalledTimes(1);
+    it('should call signoutRedirectCallback when on the post_logout_redirect_uri in the top frame', () => {
+      setWindowInTop();
+      expect(UserManager).not.toHaveBeenCalled();
+      expect(mockSignoutRedirectCallback).not.toHaveBeenCalled();
+      //@ts-ignore
+      window.location = new URL(postLogoutRedirectUri);
+      setupOidcClient(oidcConfig);
+      expect(UserManager).toHaveBeenCalledTimes(1);
+      expect(mockSignoutRedirectCallback).toHaveBeenCalledTimes(1);
+      expect(mockSignoutPopupCallback).not.toHaveBeenCalled();
+    });
+    it('should call signoutPopupCallback and signoutSilentCallback when on the post_logout_redirect_uri in an IFrame', () => {
+      setWindowInIFrame();
+      expect(UserManager).not.toHaveBeenCalled();
+      expect(mockSignoutPopupCallback).not.toHaveBeenCalled();
+      //@ts-ignore
+      window.location = new URL(postLogoutRedirectUri);
+      const client = setupOidcClient(oidcConfig);
+      expect(UserManager).toHaveBeenCalledTimes(1);
+      expect(mockSignoutPopupCallback).toHaveBeenCalledTimes(1);
+      expect(mockSignoutRedirectCallback).not.toHaveBeenCalled();
+    });
   });
 
   describe('setupOidcClient returned object', () => {
     let client: OidcClient;
-    let userManager: UserManager;
 
     beforeEach(() => {
-      jest.clearAllMocks();
       client = setupOidcClient(oidcConfig);
-      userManager = MockUserManager.mock.instances[0];
     });
 
     it('login() should signInRedirect on the UserManager', () => {
-      expect(userManager.signinRedirect).not.toHaveBeenCalled();
+      expect(mockSigninRedirect).not.toHaveBeenCalled();
       client.login();
-      expect(userManager.signinRedirect).toHaveBeenCalledTimes(1);
+      expect(mockSigninRedirect).toHaveBeenCalledTimes(1);
     });
 
     it('logout() should call signoutRedirect on the UserManager', () => {
-      expect(userManager.signoutRedirect).not.toHaveBeenCalled();
+      expect(mockSignoutRedirect).not.toHaveBeenCalled();
       client.logout();
-      expect(userManager.signoutRedirect).toHaveBeenCalledTimes(1);
+      expect(mockSignoutRedirect).toHaveBeenCalledTimes(1);
     });
 
     it('token() should get the token from the user manager', async () => {
-      const user: any = {
-        access_token: '123',
-        expires_in: 100,
-      };
-      (userManager.getUser as jest.MockedFunction<typeof userManager.getUser>).mockResolvedValue(user);
       const token = await client.token();
       expect(token).toBe(user.access_token);
     });
 
-    it('token() should signinSilent() with an expired user', async () => {
+    it('token() should get a new token via signinSilent() with an expired user', async () => {
       const user: any = {
         access_token: '123',
         expires_in: 0,
@@ -85,24 +180,20 @@ describe('Piral-Oidc setup module', () => {
         access_token: '456',
         expires_in: 10000,
       };
-      (userManager.getUser as jest.MockedFunction<typeof userManager.getUser>)
-        .mockResolvedValueOnce(user)
-        .mockResolvedValueOnce(userTwo);
-      (userManager.signinSilent as jest.MockedFunction<typeof userManager.signinSilent>).mockResolvedValue(null);
-      expect(userManager.signinSilent).not.toHaveBeenCalled();
+      mockSigninSilent.mockResolvedValueOnce(userTwo);
+      mockGetUser.mockResolvedValueOnce(user);
       const token = await client.token();
       expect(token).toBe(userTwo.access_token);
-      expect(userManager.signinSilent).toHaveBeenCalledTimes(1);
     });
 
     it('token() should reject without a user', () => {
-      (userManager.getUser as jest.MockedFunction<typeof userManager.getUser>).mockResolvedValue(null);
-      return expect(client.token()).rejects.toMatch('Not logged in.');
+      mockGetUser.mockResolvedValue(undefined);
+      return expect(client.token()).rejects.toMatch(notLoggedInMessage);
     });
 
     it('token() rejects when UserManager rejects', async () => {
       const e = new Error('test error');
-      (userManager.getUser as jest.MockedFunction<typeof userManager.getUser>).mockRejectedValue(e);
+      mockGetUser.mockRejectedValue(e);
       await expect(client.token()).rejects.toThrow(e);
     });
 
@@ -114,7 +205,7 @@ describe('Piral-Oidc setup module', () => {
           foo: 'bar',
         },
       };
-      (userManager.getUser as jest.MockedFunction<typeof userManager.getUser>).mockResolvedValue(user);
+      mockGetUser.mockResolvedValue(user);
       return expect(client.account()).resolves.toBe(user.profile);
     });
 
@@ -126,13 +217,126 @@ describe('Piral-Oidc setup module', () => {
           foo: 'bar',
         },
       };
-      (userManager.getUser as jest.MockedFunction<typeof userManager.getUser>).mockResolvedValue(user);
+      mockGetUser.mockResolvedValue(user);
       return expect(client.account()).rejects.toMatch('Not logged in.');
     });
 
     it('account() should reject when user is not authenticated', () => {
-      (userManager.getUser as jest.MockedFunction<typeof userManager.getUser>).mockResolvedValue(null);
+      mockGetUser.mockResolvedValue(undefined);
       return expect(client.account()).rejects.toMatch('Not logged in.');
+    });
+
+    it('handleAuthentication() calls signinSilentCallback when on the silent_redirect_uri path in an IFrame', async () => {
+      setWindowInIFrame();
+      //@ts-ignore
+      window.location = new URL(redirectUri);
+      expect(mockSigninSilentCallback).toBeCalledTimes(0);
+      const shouldRender = await client.handleAuthentication();
+      expect(mockSigninSilentCallback).toBeCalledTimes(1);
+      expect(mockSigninCallback).toBeCalledTimes(0);
+      expect(shouldRender).toBe(false);
+    });
+
+    it('handleAuthentication() calls signinCallback when on the redirect_uri path in the main viewport', async () => {
+      setWindowInTop();
+      //@ts-ignore
+      window.location = new URL(redirectUri);
+      expect(mockSigninCallback).toBeCalledTimes(0);
+      const shouldRender = await client.handleAuthentication();
+      expect(mockSigninSilentCallback).toBeCalledTimes(0);
+      expect(mockSigninCallback).toBeCalledTimes(1);
+      expect(shouldRender).toBe(false);
+    });
+
+    it('handleAuthentication() redirects to appUri when on the redirect_uri path in the main viewport and appUri is configured', async () => {
+      setWindowInTop();
+      const url = new URL(redirectUri);
+      //@ts-ignore
+      window.location = url;
+      expect(window.location.href).not.toBe(appUri);
+      await client.handleAuthentication();
+      expect(window.location.href).toBe(appUri);
+    });
+
+    it('handleAuthentication() does not redirect to appUri when appUri is not configured', async () => {
+      const secondClient = setupOidcClient({
+        ...oidcConfig,
+        appUri: undefined,
+      });
+
+      setWindowInTop();
+      const url = new URL(redirectUri);
+      //@ts-ignore
+      window.location = url;
+      expect(window.location.href).not.toBe(appUri);
+      const shouldRender = await secondClient.handleAuthentication();
+      expect(window.location.href).not.toBe(appUri);
+      expect(shouldRender).toBe(true);
+    });
+
+    it('handleAuthentication() returns true when the user has an acess token on normal routes', async () => {
+      const url = new URL(appUri);
+      //@ts-ignore
+      window.location = url;
+      const shouldRender = await client.handleAuthentication();
+      expect(shouldRender).toBe(true);
+    });
+
+    it('handleAuthentication() redirects to login when the user does not have an access token', async () => {
+      const url = new URL(appUri);
+      mockGetUser.mockResolvedValue(undefined);
+      //@ts-ignore
+      window.location = url;
+      expect(mockSigninRedirect).toBeCalledTimes(0);
+      const shouldRender = await client.handleAuthentication();
+      expect(mockSigninRedirect).toBeCalledTimes(1);
+      expect(shouldRender).toBe(false);
+    });
+
+    it('handleAuthentication() rejects when token() rejects', async () => {
+      const e = new Error('test error');
+      mockGetUser.mockRejectedValue(e);
+      await expect(client.handleAuthentication()).rejects.toThrow(e);
+    });
+
+    it('extendHeaders() calls request.setHeaders with the authorization header when the user has a token', async () => {
+      mockGetUser.mockResolvedValue(user);
+      const expected = { Authorization: `Bearer ${user.access_token}` };
+      const mockSetHeaders = jest.fn().mockResolvedValue(undefined);
+      const req = {
+        setHeaders: mockSetHeaders,
+      };
+      expect(mockSetHeaders).not.toHaveBeenCalled();
+      await client.extendHeaders(req);
+      expect(mockSetHeaders).toBeCalledTimes(1);
+      const retrieveTokenPromise = mockSetHeaders.mock.calls[0][0];
+      expect(await retrieveTokenPromise).toEqual(expected);
+    });
+
+    it('extendHeaders() is a noop when `restrict` is true in configuration', async () => {
+      const mockSetHeaders = jest.fn().mockResolvedValue(undefined);
+      const req = {
+        setHeaders: mockSetHeaders,
+      };
+      const client2 = setupOidcClient({
+        ...oidcConfig,
+        restrict: true,
+      });
+      await client2.extendHeaders(req);
+      expect(mockSetHeaders).not.toBeCalled();
+    });
+
+    it('extendHeaders() does nothing when the user has no token', async () => {
+      mockGetUser.mockResolvedValue(undefined);
+      const mockSetHeaders = jest.fn().mockResolvedValue(undefined);
+      const req = {
+        setHeaders: mockSetHeaders,
+      };
+      expect(mockSetHeaders).not.toHaveBeenCalled();
+      await client.extendHeaders(req);
+      expect(mockSetHeaders).toBeCalledTimes(1);
+      const retrieveTokenPromise = mockSetHeaders.mock.calls[0][0];
+      expect(await retrieveTokenPromise).toEqual(undefined);
     });
   });
 });

--- a/src/packages/piral-oidc/src/setup.test.ts
+++ b/src/packages/piral-oidc/src/setup.test.ts
@@ -107,6 +107,7 @@ describe('Piral-Oidc setup module', () => {
       expect(mockSignoutRedirectCallback).toHaveBeenCalledTimes(1);
       expect(mockSignoutPopupCallback).not.toHaveBeenCalled();
     });
+
     it('should call signoutPopupCallback and signoutSilentCallback when on the post_logout_redirect_uri in an IFrame', () => {
       setWindowInIFrame();
       expect(UserManager).not.toHaveBeenCalled();

--- a/src/packages/piral-oidc/src/setup.ts
+++ b/src/packages/piral-oidc/src/setup.ts
@@ -48,13 +48,13 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
     return new Promise<string>((res, rej) => {
       userManager
         .getUser()
-        .then(user => {
+        .then((user) => {
           if (!user) {
             rej(notLoggedInMessage);
           } else if (user.access_token && user.expires_in > 60) {
             res(user.access_token);
           } else {
-            return userManager.signinSilent().then(user => {
+            return userManager.signinSilent().then((user) => {
               if (!user || !user.access_token) {
                 throw new Error('Silent renew failed to retrieve access token');
               }
@@ -62,21 +62,21 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
             });
           }
         })
-        .catch(err => rej(err));
+        .catch((err) => rej(err));
     });
   };
 
   const retrieveProfile = () => {
     return new Promise<OidcProfileWithCustomClaims>((res, rej) => {
       userManager.getUser().then(
-        user => {
+        (user) => {
           if (!user || user.expires_in <= 0) {
             rej(notLoggedInMessage);
           } else {
             res(user.profile as OidcProfileWithCustomClaims);
           }
         },
-        err => rej(err),
+        (err) => rej(err),
       );
     });
   };
@@ -88,7 +88,7 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
           window.location.pathname === new URL(userManager.settings.popup_redirect_uri).pathname) &&
         window !== window.top
       ) {
-        /* 
+        /*
          * This is a silent redirect frame. The correct behavior is to notify the parent of the updated user,
          * and then to do nothing else. Encountering an error here means the background IFrame failed
          * to update the parent. This is usually due to a timeout from a network error.
@@ -122,20 +122,20 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
         return resolve(true);
       }
 
-      /* 
+      /*
        * The current page is a normal flow, not a callback or signout. We should retrieve the current access_token,
        * or log the user in if there is no current session.
        * This branch of code should also tell the user to render the main application.
        */
       return retrieveToken()
-        .then(token => {
+        .then((token) => {
           if (token) {
             return resolve(true);
           } else {
             return reject(new Error('Invalid token during authentication'));
           }
         })
-        .catch(async reason => {
+        .catch(async (reason) => {
           if (new RegExp(notLoggedInMessage).test(reason)) {
             /*
              * Expected Error during normal code flow:
@@ -170,7 +170,7 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
       if (!restrict) {
         req.setHeaders(
           retrieveToken().then(
-            token => token && { Authorization: `Bearer ${token}` },
+            (token) => token && { Authorization: `Bearer ${token}` },
             () => undefined,
           ),
         );

--- a/src/packages/piral-oidc/src/setup.ts
+++ b/src/packages/piral-oidc/src/setup.ts
@@ -1,6 +1,8 @@
 import { UserManager, Log } from 'oidc-client';
 import { OidcConfig, OidcClient, OidcProfileWithCustomClaims } from './types';
 
+const notLoggedInMessage = 'Not logged in. Please call `login()` to retrieve a token.';
+
 /**
  * Sets up a new client wrapping the oidc-client API.
  * @param config The configuration for the client.
@@ -15,7 +17,9 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
     responseType,
     scopes,
     restrict = false,
+    appUri,
   } = config;
+
   const userManager = new UserManager({
     authority: identityProviderUri,
     redirect_uri: redirectUri,
@@ -32,54 +36,141 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
     Log.level = Log.DEBUG;
   }
 
-  userManager.signinRedirectCallback();
-  userManager.signinSilentCallback();
-  userManager.signoutRedirectCallback();
+  if (window.location.pathname === new URL(userManager.settings.post_logout_redirect_uri).pathname) {
+    if (window === window.top) {
+      userManager.signoutRedirectCallback();
+    } else {
+      userManager.signoutPopupCallback();
+    }
+  }
 
   const retrieveToken = () => {
     return new Promise<string>((res, rej) => {
-      userManager.getUser().then(
-        (user) => {
+      userManager
+        .getUser()
+        .then(user => {
           if (!user) {
-            rej('Not logged in. Please call `login()` to retrieve a token.');
+            rej(notLoggedInMessage);
           } else if (user.access_token && user.expires_in > 60) {
             res(user.access_token);
           } else {
-            userManager.signinSilent().then(() => retrieveToken().then(res, rej), rej);
+            return userManager.signinSilent().then(user => {
+              if (!user || !user.access_token) {
+                throw new Error('Silent renew failed to retrieve access token');
+              }
+              return res(user.access_token);
+            });
           }
-        },
-        (err) => rej(err),
-      );
+        })
+        .catch(err => rej(err));
     });
   };
 
   const retrieveProfile = () => {
     return new Promise<OidcProfileWithCustomClaims>((res, rej) => {
       userManager.getUser().then(
-        (user) => {
+        user => {
           if (!user || user.expires_in <= 0) {
-            rej('Not logged in. Please call `login()` to retreive the current profile.');
+            rej(notLoggedInMessage);
           } else {
             res(user.profile as OidcProfileWithCustomClaims);
           }
         },
-        (err) => rej(err),
+        err => rej(err),
       );
     });
   };
 
+  const handleAuthentication = (): Promise<boolean> =>
+    new Promise(async (resolve, reject) => {
+      if (
+        (window.location.pathname === new URL(userManager.settings.silent_redirect_uri).pathname ||
+          window.location.pathname === new URL(userManager.settings.popup_redirect_uri).pathname) &&
+        window !== window.top
+      ) {
+        /* 
+         * This is a silent redirect frame. The correct behavior is to notify the parent of the updated user,
+         * and then to do nothing else. Encountering an error here means the background IFrame failed
+         * to update the parent. This is usually due to a timeout from a network error.
+         */
+        try {
+          await userManager.signinSilentCallback();
+        } catch (e) {
+          return reject(e);
+        }
+        return resolve(false);
+      }
+
+      if (window.location.pathname === new URL(userManager.settings.redirect_uri).pathname && window === window.top) {
+        try {
+          await userManager.signinCallback();
+        } catch (e) {
+          /*
+           * Failing to handle a sign-in callback is non-recoverable. The user is expected to call `logout()`, after
+           * logging this error to their internal error-handling service. Usually, this is due to a misconfigured auth server.
+           */
+          return reject(e);
+        }
+
+        if (appUri) {
+          Log.debug(`Redirecting to ${appUri} due to appUri being configured.`);
+          window.location.href = appUri;
+          return resolve(false);
+        }
+
+        /* If appUri is not configured, we let the user decide what to do after getting a session. */
+        return resolve(true);
+      }
+
+      /* 
+       * The current page is a normal flow, not a callback or signout. We should retrieve the current access_token,
+       * or log the user in if there is no current session.
+       * This branch of code should also tell the user to render the main application.
+       */
+      return retrieveToken()
+        .then(token => {
+          if (token) {
+            return resolve(true);
+          } else {
+            return reject(new Error('Invalid token during authentication'));
+          }
+        })
+        .catch(async reason => {
+          if (new RegExp(notLoggedInMessage).test(reason)) {
+            /*
+             * Expected Error during normal code flow:
+             * This is the first time logging in since a logout (or ever), instead of asking the user
+             * to call `login()`, just perform it ourself here.
+             *
+             * The resolve shouldn't matter, as `signinRedirect` will redirect the browser location
+             * to the user's configured redirectUri.
+             */
+            await userManager.signinRedirect();
+            return resolve(false);
+          }
+
+          /*
+           * Getting here is a non-recoverable error. It is up to the user to determine what to do.
+           * Usually this is a result of failing to reach the authentication server, or a misconfigured
+           * authentication server, or a bad clock skew (commonly caused by docker in windows).
+           */
+          return reject(reason);
+        });
+    });
+
   return {
     login() {
-      userManager.signinRedirect();
+      return userManager.signinRedirect();
     },
     logout() {
-      userManager.signoutRedirect();
+      return userManager.signoutRedirect();
     },
+    handleAuthentication,
     extendHeaders(req) {
       if (!restrict) {
         req.setHeaders(
           retrieveToken().then(
-            (token) => token && { Authorization: `Bearer ${token}` },
+            token => token && { Authorization: `Bearer ${token}` },
             () => undefined,
           ),
         );
@@ -87,5 +178,6 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
     },
     token: retrieveToken,
     account: retrieveProfile,
+    events: userManager.events,
   };
 }

--- a/src/packages/piral-oidc/src/setup.ts
+++ b/src/packages/piral-oidc/src/setup.ts
@@ -199,7 +199,6 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
       }
     },
     token: retrieveToken,
-    account: retrieveProfile,
-    events: userManager.events,
+    account: retrieveProfile
   };
 }

--- a/src/packages/piral-oidc/src/setup.ts
+++ b/src/packages/piral-oidc/src/setup.ts
@@ -29,6 +29,7 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
     authority: identityProviderUri,
     redirect_uri: redirectUri,
     silent_redirect_uri: redirectUri,
+    popup_redirect_uri: redirectUri,
     post_logout_redirect_uri: postLogoutRedirectUri,
     client_id: clientId,
     client_secret: clientSecret,

--- a/src/packages/piral-oidc/src/setup.ts
+++ b/src/packages/piral-oidc/src/setup.ts
@@ -2,6 +2,8 @@ import { UserManager, Log } from 'oidc-client';
 import { OidcConfig, OidcClient, OidcProfileWithCustomClaims, OidcErrorType, LogLevel } from './types';
 import { OidcError } from './OidcError';
 
+const doesWindowLocationMatch = (targetUri: string) => window.location.pathname === new URL(targetUri).pathname;
+
 const logLevelToOidcMap = {
   [LogLevel.none]: 0,
   [LogLevel.error]: 1,
@@ -52,7 +54,7 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
     Log.level = Log.DEBUG;
   }
 
-  if (window.location.pathname === new URL(userManager.settings.post_logout_redirect_uri).pathname) {
+  if (doesWindowLocationMatch(userManager.settings.post_logout_redirect_uri)) {
     if (window === window.top) {
       userManager.signoutRedirectCallback();
     } else {
@@ -103,8 +105,8 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
   const handleAuthentication = (): Promise<boolean> =>
     new Promise(async (resolve, reject) => {
       if (
-        (window.location.pathname === new URL(userManager.settings.silent_redirect_uri).pathname ||
-          window.location.pathname === new URL(userManager.settings.popup_redirect_uri).pathname) &&
+        (doesWindowLocationMatch(userManager.settings.silent_redirect_uri) ||
+          doesWindowLocationMatch(userManager.settings.popup_redirect_uri)) &&
         window !== window.top
       ) {
         /*
@@ -120,7 +122,7 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
         return resolve(false);
       }
 
-      if (window.location.pathname === new URL(userManager.settings.redirect_uri).pathname && window === window.top) {
+      if (doesWindowLocationMatch(userManager.settings.redirect_uri) && window === window.top) {
         try {
           await userManager.signinCallback();
         } catch (e) {

--- a/src/packages/piral-oidc/src/setup.ts
+++ b/src/packages/piral-oidc/src/setup.ts
@@ -23,6 +23,7 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
     scopes,
     restrict = false,
     appUri,
+    logLevel,
   } = config;
 
   const userManager = new UserManager({
@@ -37,7 +38,10 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
     scope: scopes?.join(' '),
   });
 
-  if (process.env.NODE_ENV === 'development') {
+  if (logLevel !== undefined) {
+    Log.logger = console;
+    Log.level = logLevel;
+  } else if (process.env.NODE_ENV === 'development') {
     Log.logger = console;
     Log.level = Log.DEBUG;
   }

--- a/src/packages/piral-oidc/src/setup.ts
+++ b/src/packages/piral-oidc/src/setup.ts
@@ -53,13 +53,13 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
     return new Promise<string>((res, rej) => {
       userManager
         .getUser()
-        .then(user => {
+        .then((user) => {
           if (!user) {
             rej(notLoggedInMessage);
           } else if (user.access_token && user.expires_in > 60) {
             res(user.access_token);
           } else {
-            return userManager.signinSilent().then(user => {
+            return userManager.signinSilent().then((user) => {
               if (!user || !user.access_token) {
                 throw new Error(silentRenewFailedMessage);
               }
@@ -67,21 +67,21 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
             });
           }
         })
-        .catch(err => rej(err));
+        .catch((err) => rej(err));
     });
   };
 
   const retrieveProfile = () => {
     return new Promise<OidcProfileWithCustomClaims>((res, rej) => {
       userManager.getUser().then(
-        user => {
+        (user) => {
           if (!user || user.expires_in <= 0) {
             rej(notLoggedInMessage);
           } else {
             res(user.profile as OidcProfileWithCustomClaims);
           }
         },
-        err => rej(err),
+        (err) => rej(err),
       );
     });
   };
@@ -133,7 +133,7 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
        * This branch of code should also tell the user to render the main application.
        */
       return retrieveToken()
-        .then(token => {
+        .then((token) => {
           if (token) {
             return resolve(true);
           } else {
@@ -141,7 +141,7 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
             return reject(new Error(invalidTokenMessage));
           }
         })
-        .catch(async reason => {
+        .catch(async (reason) => {
           if (reason.message === notLoggedInMessage || reason === notLoggedInMessage) {
             /*
              * Expected Error during normal code flow:
@@ -176,7 +176,7 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
       if (!restrict) {
         req.setHeaders(
           retrieveToken().then(
-            token => token && { Authorization: `Bearer ${token}` },
+            (token) => token && { Authorization: `Bearer ${token}` },
             () => undefined,
           ),
         );

--- a/src/packages/piral-oidc/src/setup.ts
+++ b/src/packages/piral-oidc/src/setup.ts
@@ -3,15 +3,15 @@ import { OidcConfig, OidcClient, OidcProfileWithCustomClaims, OidcErrorType, Log
 import { OidcError } from './OidcError';
 
 const logLevelToOidcMap = {
-    [LogLevel.none]: 0,
-    [LogLevel.error]: 1,
-    [LogLevel.warn]: 2,
-    [LogLevel.info]: 3,
-    [LogLevel.debug]: 4,
+  [LogLevel.none]: 0,
+  [LogLevel.error]: 1,
+  [LogLevel.warn]: 2,
+  [LogLevel.info]: 3,
+  [LogLevel.debug]: 4,
 };
 
-const convertLogLevelToOidcClient = (level: LogLevel ) => {
-    return logLevelToOidcMap[level];
+const convertLogLevelToOidcClient = (level: LogLevel) => {
+  return logLevelToOidcMap[level];
 };
 
 /**
@@ -64,38 +64,38 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
     return new Promise<string>((res, rej) => {
       userManager
         .getUser()
-        .then(user => {
+        .then((user) => {
           if (!user) {
             rej(new OidcError(OidcErrorType.notAuthorized));
           } else if (user.access_token && user.expires_in > 60) {
             res(user.access_token);
           } else {
-            return userManager.signinSilent().then(user => {
+            return userManager.signinSilent().then((user) => {
               if (!user) {
                 return rej(new OidcError(OidcErrorType.silentRenewFailed));
               }
               if (!user.access_token) {
-                  return rej(new OidcError(OidcErrorType.invalidToken));
+                return rej(new OidcError(OidcErrorType.invalidToken));
               }
               return res(user.access_token);
             });
           }
         })
-        .catch(err => rej(new OidcError(OidcErrorType.unknown, err)));
+        .catch((err) => rej(new OidcError(OidcErrorType.unknown, err)));
     });
   };
 
   const retrieveProfile = () => {
     return new Promise<OidcProfileWithCustomClaims>((res, rej) => {
       userManager.getUser().then(
-        user => {
+        (user) => {
           if (!user || user.expires_in <= 0) {
             return rej(new OidcError(OidcErrorType.notAuthorized));
           } else {
             return res(user.profile as OidcProfileWithCustomClaims);
           }
         },
-        err => rej(new OidcError(OidcErrorType.unknown, err)),
+        (err) => rej(new OidcError(OidcErrorType.unknown, err)),
       );
     });
   };
@@ -147,7 +147,7 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
        * This branch of code should also tell the user to render the main application.
        */
       return retrieveToken()
-        .then(token => {
+        .then((token) => {
           if (token) {
             return resolve(true);
           } else {
@@ -190,7 +190,7 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
       if (!restrict) {
         req.setHeaders(
           retrieveToken().then(
-            token => token && { Authorization: `Bearer ${token}` },
+            (token) => token && { Authorization: `Bearer ${token}` },
             () => undefined,
           ),
         );

--- a/src/packages/piral-oidc/src/types.ts
+++ b/src/packages/piral-oidc/src/types.ts
@@ -89,12 +89,12 @@ export interface OidcClient {
    */
   logout(): Promise<void>;
   /**
-   * Performs a login when the app needs a new token, handles callbacks when on 
+   * Performs a login when the app needs a new token, handles callbacks when on
    * a callback URL, and redirects into the app route if the client was configured with an `appUri`.
-   * 
+   *
    * When this resolves to true, the app-shell should call its `render()` method.
    * When this resolves to false, do not call `render()`.
-   * 
+   *
    * If this rejects, the app-shell should redirect to the login page or handle
    * an authentication failure manually, it is also advised to log this error to a logging service,
    * as no users will be be authorized to enter the application.

--- a/src/packages/piral-oidc/src/types.ts
+++ b/src/packages/piral-oidc/src/types.ts
@@ -1,5 +1,5 @@
 import 'piral-core';
-import { Profile, UserManagerEvents } from 'oidc-client';
+import { Profile } from 'oidc-client';
 
 /**
  * Available configuration options for the OpenID Connect plugin.
@@ -125,10 +125,6 @@ export interface OidcClient {
    * Extends the headers of the provided request.
    */
   extendHeaders(req: OidcRequest): void;
-  /**
-   * The internal oidc-client library User Manager events.
-   */
-  events: UserManagerEvents;
 }
 
 export interface PiralOidcApi {

--- a/src/packages/piral-oidc/src/types.ts
+++ b/src/packages/piral-oidc/src/types.ts
@@ -47,6 +47,19 @@ export interface OidcConfig {
    * a new session from the redirectUri callback.
    */
   appUri?: string;
+  /**
+   * If provided, logging will be enabled for the oidc-client.
+   * Defaults to Log.DEBUG in development NODE_ENV.
+   */
+  logLevel?: LogLevel;
+}
+
+export enum LogLevel {
+  NONE = 0,
+  ERROR = 1,
+  WARN = 2,
+  INFO = 3,
+  DEBUG = 4,
 }
 
 /**

--- a/src/packages/piral-oidc/src/types.ts
+++ b/src/packages/piral-oidc/src/types.ts
@@ -54,12 +54,12 @@ export interface OidcConfig {
   logLevel?: LogLevel;
 }
 
-export enum LogLevel {
-  NONE = 0,
-  ERROR = 1,
-  WARN = 2,
-  INFO = 3,
-  DEBUG = 4,
+export const enum LogLevel {
+  none = 'none',
+  error = 'error',
+  warn = 'warn',
+  info = 'info',
+  debug = 'debug',
 }
 
 /**
@@ -145,4 +145,42 @@ export interface PiralOidcApi {
 
 declare module 'piral-core/lib/types/custom' {
   interface PiletCustomApi extends PiralOidcApi {}
+}
+
+export const enum OidcErrorType {
+  /**
+   * This error was thrown at some point during authentication, by the browser or by oidc-client
+   * and we are unable to handle it.
+   */
+  unknown = 'unknown',
+  /**
+   * This error happens when the user does not have an access token during Authentication.
+   * It is an expected error, and should be handled during `handleAuthentication()` calls.
+   * If doing manual authentication, prompt the user to `login()` when receiving it.
+   */
+  notAuthorized = 'notAuthorized',
+  /**
+   * This error happens when silent renew fails in the background. It is not expected, and
+   * signifies a network error or configuration problem.
+   */
+  silentRenewFailed = 'silentRenewFailed',
+  /**
+   * This is an unexpected error that happens when the `token()` call retrieves a User from
+   * the user manager, but it does not have an access_token. This signifies a configuration
+   * error, make sure the correct `scopes` are supplied during configuration.
+   */
+  invalidToken = 'invalidToken',
+  /**
+   * This error happened during an Open ID callback. This signifies a network or configuration error
+   * which is non-recoverable. This should be logged to a logging service, and the user should be
+   * prompted to logout().
+   */
+  oidcCallback = 'oidcCallback',
+}
+
+/**
+ * This Error is used for Authentication errors in piral-oidc.
+ */
+export interface PiralOidcError extends Error {
+  type: Readonly<OidcErrorType>;
 }


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes

### Description

Fixes #219 , adds `handleAuthentication()` call that can be called from the app-shell to automatically route and call correct callbacks. When it resolves to true, the user should render the app. When it resolves to false, the user should not render the app. When it rejects, the user should log the error and call signout().

### Remarks

I didn't want to overwrite account() low-level method with this, because some users will still want to be able to handle things themselves manually.

There are also some smaller features added here too that will likely be commonly used:
* Added the OIDC events to the public interface to be able to respond to these when needed
* Added a configuration option for OIDC Logging