### PR TITLE
augment downloadFile to include cacert in request if provided #239

### DIFF
--- a/src/tooling/piral-cli/src/common/http.ts
+++ b/src/tooling/piral-cli/src/common/http.ts
@@ -30,13 +30,15 @@ function streamToFile(source: Stream, target: string) {
   });
 }
 
-export function downloadFile(target: string): Promise<Array<string>> {
+export function downloadFile(target: string, ca?: Buffer): Promise<Array<string>> {
+  const httpsAgent = ca ? new Agent({ ca }) : undefined;
   return axios.default
     .get<Stream>(target, {
       responseType: 'stream',
       headers: {
         'user-agent': `piral-cli/http.node-${os}`,
       },
+      httpsAgent,
     })
     .then(res => {
       const rid = Math.random().toString(36).split('.').pop();


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

### Description

When testing the new feature #239, we weren't able to publish pilet from npm because our private npm registry require the request to include cacert

```
[0068] Failed to download via HTTP: self signed certificate in certificate chain.
```

This change _should_ resolve the cert issue.

### Remarks

I'm not sure how to test this change locally... 🤞 
