### PR TITLE
Fixed a typo in code example of the piral-ng plugin documentation

### DIFF
--- a/src/converters/piral-ng/README.md
+++ b/src/converters/piral-ng/README.md
@@ -64,10 +64,10 @@ import 'zone.js/dist/zone';
 Furthermore, switching on the production mode may be useful.
 
 ```ts
-import { enableProdMod } from '@angular/core';
+import { enableProdMode } from '@angular/core';
 
 if (process.env.NODE_ENV === 'production') {
-  enableProdMod();
+  enableProdMode();
 }
 ```
 


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x ] I have read the **CONTRIBUTING** document
- [x ] My code follows the code style of this project
- [x] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

### Description

The README.md file that contains the documentation for the piral-ng plugin contains the code example:

```
import { enableProdMod } from '@angular/core';

if (process.env.NODE_ENV === 'production') {
  enableProdMod();
}
```
However the function is actually called `enableProdMode` as stated in the official [Angular Documenation](https://angular.io/api/core/enableProdMode)

### Remarks

[Optionally place any follow-up comments, remarks, observations, or notes here for future reference]
