### PR TITLE
Improved test coverage in piral-core and piral-base

### DIFF
--- a/src/framework/piral-base/src/strategies.test.ts
+++ b/src/framework/piral-base/src/strategies.test.ts
@@ -1,4 +1,4 @@
-import { blazingStrategy, standardStrategy, syncStrategy } from './strategies';
+import { asyncStrategy, blazingStrategy, standardStrategy, syncStrategy, createProgressiveStrategy } from './strategies';
 import { PiletMetadata, LoadPiletsOptions, Pilet } from './types';
 
 function createMockApi(meta: PiletMetadata) {
@@ -76,6 +76,45 @@ describe('Piral-Base strategies module', () => {
     expect(callbackMock).toHaveBeenCalledTimes(1);
     expect(callbackMock.mock.calls[0][0]).not.toBeUndefined();
     expect(callbackMock.mock.calls[0][1]).toHaveLength(0);
+  });
+
+  it('blazingStrategy evaluates with predefined pilets', async () => {
+    // Arrange
+    const setupMock = jest.fn();
+    const callbackMock = jest.fn();
+    const pilets: Array<Pilet> = [
+      {
+        setup: setupMock,
+        hash: '12g',
+        name: 'somePilet',
+        version: '1',
+      },
+      {
+        setup: setupMock,
+        hash: '99a',
+        name: 'anotherPilet',
+        version: '2',
+      },
+    ];
+    const loadingOptions: LoadPiletsOptions = {
+      createApi: createMockApi,
+      pilets: pilets,
+      fetchPilets: jest.fn(() => Promise.resolve(pilets)),
+      loadPilet: jest.fn(m => Promise.resolve(m as any)),
+      fetchDependency: jest.fn(),
+      dependencies: jest.fn(),
+      getDependencies: jest.fn(),
+    };
+
+    // Act
+    await blazingStrategy(loadingOptions, callbackMock);
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    // Assert
+    expect(setupMock).toHaveBeenCalledTimes(pilets.length);
+    expect(callbackMock).toHaveBeenCalledTimes(1);
+    expect(callbackMock.mock.calls[0][0]).toBeUndefined();
+    expect(callbackMock.mock.calls[0][1]).toHaveLength(pilets.length);
   });
 
   it('blazingStrategy evaluates all in one sweep', async () => {
@@ -229,5 +268,60 @@ describe('Piral-Base strategies module', () => {
     // Assert
     expect(setupMock).toHaveBeenCalledTimes(0);
     expect(callbackMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('progressiveStrategy evaluates synchronously', async () => {
+    // Arrange
+    const setupMock = jest.fn();
+    const callbackMock = jest.fn();
+    const pilets: Array<Pilet> = [
+      {
+        setup: setupMock,
+        hash: '12g',
+        name: 'somePilet',
+        version: '1',
+      },
+      {
+        setup: setupMock,
+        hash: '99a',
+        name: 'anotherPilet',
+        version: '2',
+      },
+    ];
+    const loadingOptions: LoadPiletsOptions = {
+      createApi: createMockApi,
+      fetchPilets: jest.fn(() => Promise.resolve(pilets)),
+      pilets: pilets,
+    };
+
+    // Act
+    const strategy = createProgressiveStrategy(false)
+    await strategy(loadingOptions, callbackMock);
+
+    // Assert
+    expect(setupMock).toHaveBeenCalledTimes(pilets.length);
+    expect(callbackMock).toHaveBeenCalledTimes(1);
+    expect(callbackMock.mock.calls[0][0]).toBeUndefined();
+    expect(callbackMock.mock.calls[0][1]).toHaveLength(pilets.length);
+  });
+
+  it('asyncStrategy evaluates also with no modules', async () => {
+    // Arrange
+    const callbackMock = jest.fn();
+    const loadingOptions: LoadPiletsOptions = {
+      createApi: createMockApi,
+      fetchPilets: jest.fn(() => Promise.resolve([])),
+      pilets: [],
+    };
+
+    // Act
+    await asyncStrategy(loadingOptions, callbackMock);
+
+    // Assert (We gonna wait since the pilet loading happens asynchronously)
+    setTimeout(() => {
+      expect(callbackMock).toHaveBeenCalledTimes(1);
+      expect(callbackMock.mock.calls[0][0]).toBeUndefined();
+      expect(callbackMock.mock.calls[0][1]).toHaveLength(0);
+    }, 1000);
   });
 });

--- a/src/framework/piral-core/src/helpers.test.tsx
+++ b/src/framework/piral-core/src/helpers.test.tsx
@@ -1,35 +1,177 @@
-import { createPiletOptions } from './helpers';
+import { createPiletOptions, PiletOptionsConfig } from './helpers';
 import { globalDependencies } from './modules';
+import { GlobalStateContext } from './types';
+import { PiletApiCreator, PiletMetadata, Pilet } from 'piral-base';
+import { Atom, swap } from '@dbeining/react-atom';
+
+function createMockApi(meta: PiletMetadata){
+  return {
+    meta,
+    emit: jest.fn(),
+    off: jest.fn(),
+    on: jest.fn(),
+  }as any;
+}
+
+function createMockContainer() {
+  const state = Atom.of({
+    components: {},
+  });
+  return {
+    context: {
+      on: jest.fn(),
+      off: jest.fn(),
+      emit: jest.fn(),
+      state,
+      setComponent(name, comp) {
+        swap(state, s => ({
+          ...s,
+          components: {
+            ...s.components,
+            [name]: comp,
+          },
+        }));
+      },
+    } as any,
+  };
+}
 
 describe('Piral-Core helpers module', () => {
   it('createPiletOptions creates the options using the provided pilets', () => {
-    const options = createPiletOptions({
-      availablePilets: [],
-      context: {},
-      createApi: () => ({}),
-    });
-    expect(options.pilets).toEqual([]);
+
+    const wasUndefined = process.env.DEBUG_PIRAL === undefined;
+
+    process.env.DEBUG_PIRAL = "true";
+
+    // Arrange
+    const setupMock = jest.fn();
+    const globalContext = createMockContainer().context
+    const providedPilets: Array<Pilet> = [
+      {
+        setup: setupMock,
+        hash: '12g',
+        name: 'somePilet',
+        version: '1',
+      },
+      {
+        setup: setupMock,
+        hash: '99a',
+        name: 'anotherPilet',
+        version: '2',
+      },
+    ];
+    const optionsConfig: PiletOptionsConfig = {
+      createApi: createMockApi,
+      availablePilets: providedPilets,
+      context: globalContext,
+      fetchDependency: jest.fn(),
+      getDependencies: jest.fn(),
+      loadPilet: jest.fn(),
+      requestPilets: jest.fn(() => Promise.resolve(providedPilets)),
+      strategy: jest.fn()
+    }
+
+    // Act
+    const options = createPiletOptions(optionsConfig);
+
+    // Assert
+    expect(options.pilets.length).toEqual(providedPilets.length);
+
+    if(wasUndefined) {
+      process.env.DEBUG_PIRAL = undefined;
+    }
   });
 
   it('createPiletOptions creates the options exposing the global dependencies', () => {
-    const options = createPiletOptions({
-      availablePilets: [],
-      context: {},
-      createApi: () => ({}),
-    });
+
+    // Arrange
+    const setupMock = jest.fn();
+    const globalContext = createMockContainer().context
+    const providedPilets: Array<Pilet> = [
+      {
+        setup: setupMock,
+        hash: '12g',
+        name: 'somePilet',
+        version: '1',
+      },
+      {
+        setup: setupMock,
+        hash: '99a',
+        name: 'anotherPilet',
+        version: '2',
+      },
+    ];
+    const optionsConfig: PiletOptionsConfig = {
+      createApi: createMockApi,
+      availablePilets: providedPilets,
+      context: globalContext,
+      fetchDependency: jest.fn(),
+      getDependencies: () => globalDependencies,
+      loadPilet: jest.fn(),
+      requestPilets: jest.fn(() => Promise.resolve(providedPilets)),
+      strategy: jest.fn()
+    }
+
+    // Act
+    const options = createPiletOptions(optionsConfig);
+
+    // Assert
     expect(options.dependencies).toEqual(globalDependencies);
   });
 
   it('createPiletOptions creates the options with provided requestPilets', () => {
-    const requestPilets = jest.fn();
-    const options = createPiletOptions({
-      availablePilets: [],
-      context: {},
-      createApi: () => ({}),
-      requestPilets,
-    });
-    expect(requestPilets).not.toHaveBeenCalled();
+    // const requestPilets = jest.fn();
+    // const options = createPiletOptions({
+    //   availablePilets: [],
+    //   context: {},
+    //   createApi: () => ({}),
+    //   requestPilets,
+    // });
+    // expect(requestPilets).not.toHaveBeenCalled();
+    // options.fetchPilets();
+    // expect(requestPilets).toHaveBeenCalled();
+
+    const wasUndefined = process.env.DEBUG_PIRAL === undefined;
+
+    // Arrange
+    process.env.DEBUG_PIRAL = "true";
+    const setupMock = jest.fn();
+    const requestPilets = jest.fn(() => Promise.resolve(providedPilets));
+    const globalContext = createMockContainer().context
+    const providedPilets: Array<Pilet> = [
+      {
+        setup: setupMock,
+        hash: '12g',
+        name: 'somePilet',
+        version: '1',
+      },
+      {
+        setup: setupMock,
+        hash: '99a',
+        name: 'anotherPilet',
+        version: '2',
+      },
+    ];
+    const optionsConfig: PiletOptionsConfig = {
+      createApi: createMockApi,
+      availablePilets: providedPilets,
+      context: globalContext,
+      fetchDependency: jest.fn(),
+      getDependencies: jest.fn(),
+      loadPilet: jest.fn(),
+      requestPilets: requestPilets,
+      strategy: jest.fn()
+    }
+
+    // Act
+    const options = createPiletOptions(optionsConfig);
     options.fetchPilets();
+
+    // Assert
     expect(requestPilets).toHaveBeenCalled();
+
+    if(wasUndefined) {
+      process.env.DEBUG_PIRAL = undefined;
+    }
   });
 });

--- a/src/framework/piral-core/src/helpers.test.tsx
+++ b/src/framework/piral-core/src/helpers.test.tsx
@@ -1,7 +1,6 @@
 import { createPiletOptions, PiletOptionsConfig } from './helpers';
 import { globalDependencies } from './modules';
-import { GlobalStateContext } from './types';
-import { PiletApiCreator, PiletMetadata, Pilet } from 'piral-base';
+import { PiletMetadata, Pilet } from 'piral-base';
 import { Atom, swap } from '@dbeining/react-atom';
 
 function createMockApi(meta: PiletMetadata){
@@ -120,16 +119,6 @@ describe('Piral-Core helpers module', () => {
   });
 
   it('createPiletOptions creates the options with provided requestPilets', () => {
-    // const requestPilets = jest.fn();
-    // const options = createPiletOptions({
-    //   availablePilets: [],
-    //   context: {},
-    //   createApi: () => ({}),
-    //   requestPilets,
-    // });
-    // expect(requestPilets).not.toHaveBeenCalled();
-    // options.fetchPilets();
-    // expect(requestPilets).toHaveBeenCalled();
 
     const wasUndefined = process.env.DEBUG_PIRAL === undefined;
 


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes

### Description

- Created three test cases for helper.tsx within piral-core
- Bumped test coverage in piral-base/src/strategies.ts from 5 unvovered lines down to 1 by adding three new test cases

### Remarks

[Optionally place any follow-up comments, remarks, observations, or notes here for future reference]
