### PR TITLE
Improved test coverage in framework module

### DIFF
--- a/src/framework/piral-core/src/helpers.test.tsx
+++ b/src/framework/piral-core/src/helpers.test.tsx
@@ -68,21 +68,6 @@ describe('Piral-Core helpers module', () => {
     expect(extendedDependecies).not.toBeUndefined();
   });
 
-  it('extendSharedDependencies should extend the dependecies', () => {
-
-    // Arrange
-    const additionalDependencies: AvailableDependencies = {
-      "gg": {},
-      "ff": {}
-    }
-
-    // Act
-    const extendedDependecies = extendSharedDependencies(additionalDependencies);
-
-    // Assert
-    expect(extendedDependecies).not.toBeUndefined();
-  });
-
   it('createPiletOptions creates the options using the provided pilets', () => {
 
     const wasUndefined = process.env.DEBUG_PIRAL === undefined;


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes

### Description

Bumped the the test coverage in piral-core/src/helpers.tsx from 32% to 54% by adding 4 new test cases

### Remarks

I see no way to increase the testing coverage here since the helper.tsx file contains javascript code that seems to be executed by the browser and so can not be called within testing since we are relying on node.js. If you see an alternative, please let me know, otherwise feel free to merge.

As for now the following three files are covered as follows:
- strategies.ts (98%)
- fetch.ts (100%)
- helpers.tsx (54%)
