### PR TITLE
support post piral build lifecycle hooks

### DIFF
--- a/src/tooling/piral-cli/src/apps/build-piral.ts
+++ b/src/tooling/piral-cli/src/apps/build-piral.ts
@@ -122,11 +122,15 @@ export const buildPiralDefaults: BuildPiralOptions = {
   optimizeModules: false,
 };
 
-async function runLifecycle(root: string, script: string | undefined, type: string) {
+async function runLifecycle(root: string, scripts: Record<string, string>, type: string) {
+  const script = scripts?.[type];
+  
   if (script) {
-    log('generalDebug_0003', `Running "piral:postbuild" script for type=${type}...`);
+    log('generalDebug_0003', `Running "${type}" ("${script}") ...`);
     await runScript(script, root);
-    log('generalDebug_0003', `Successfully "piral:postbuild" script for type=${type}...`);
+    log('generalDebug_0003', `Finished running "${type}".`);
+  } else {
+    log('generalDebug_0003', `No script for "${type}" found ...`);
   }
 }
 
@@ -188,9 +192,8 @@ export async function buildPiral(baseDir = process.cwd(), options: BuildPiralOpt
       ignored,
     });
 
-    // run post piral build script if provided, more specific script takes precedent
-    const postBuildScript = scripts['piral:postbuild-develop'] || scripts['piral:postbuild'];
-    await runLifecycle(root, postBuildScript, "develop");
+    await runLifecycle(root, scripts, 'piral:postbuild');
+    await runLifecycle(root, scripts, 'piral:postbuild-emulator');
 
     const rootDir = await createEmulatorPackage(root, outDir, outFile);
 
@@ -226,9 +229,8 @@ export async function buildPiral(baseDir = process.cwd(), options: BuildPiralOpt
       ignored,
     });
 
-    // run post piral build script if provided, more specific script takes precedent
-    const postBuildScript = scripts['piral:postbuild-release'] || scripts['piral:postbuild'];
-    await runLifecycle(root, postBuildScript, "release");
+    await runLifecycle(root, scripts, 'piral:postbuild');
+    await runLifecycle(root, scripts, 'piral:postbuild-release');
 
     logDone(`Files for publication available in "${outDir}".`);
     logReset();

--- a/src/tooling/piral-cli/src/apps/build-piral.ts
+++ b/src/tooling/piral-cli/src/apps/build-piral.ts
@@ -13,6 +13,8 @@ import {
   logReset,
   createEmulatorPackage,
   logInfo,
+  readJson,
+  runScript,
 } from '../common';
 
 interface Destination {
@@ -98,6 +100,9 @@ export async function buildPiral(baseDir = process.cwd(), options: BuildPiralOpt
     await removeDirectory(dest.outDir);
   }
 
+  const pckg = await readJson(root, 'package.json');
+  const { postPiralBuildDevelop, postPiralBuildRelease } = pckg.scripts;
+
   // everything except release -> build develop
   if (type !== 'release') {
     progress('Starting build ...');
@@ -125,6 +130,14 @@ export async function buildPiral(baseDir = process.cwd(), options: BuildPiralOpt
       logLevel,
       ignored,
     });
+
+    // run post piral build script if provided
+    if (postPiralBuildDevelop) {
+      progress(`Running 'postPiralBuildDevelop' script ...`);
+      logInfo(`Run: ${postPiralBuildDevelop}`);
+      await runScript(postPiralBuildDevelop, root);
+      logInfo(`Successfully ran 'postPiralBuildDevelop' script.`);
+    }
 
     const rootDir = await createEmulatorPackage(root, outDir, outFile);
 
@@ -159,6 +172,14 @@ export async function buildPiral(baseDir = process.cwd(), options: BuildPiralOpt
       logLevel,
       ignored,
     });
+
+    // run post piral build script if provided
+    if (postPiralBuildRelease) {
+      progress(`Running 'postPiralBuildRelease' script ...`);
+      logInfo(`Run: ${postPiralBuildRelease}`);
+      await runScript(postPiralBuildRelease, root);
+      logInfo(`Successfully ran 'postPiralBuildRelease' script.`);
+    }
 
     logDone(`Files for publication available in "${outDir}".`);
     logReset();

--- a/src/tooling/piral-cli/src/common/package.ts
+++ b/src/tooling/piral-cli/src/common/package.ts
@@ -367,6 +367,7 @@ export async function retrievePiletsInfo(entryFile: string) {
       dev: packageInfo.devDependencies || {},
       peer: packageInfo.peerDependencies || {},
     },
+    scripts: packageInfo.scripts,
     ignored: checkArrayOrUndefined(packageInfo, 'preservedDependencies'),
     root: dirname(packageJson),
   };


### PR DESCRIPTION
Similarly to npm pre- post- hooks, this support allows performing operations on the package post piral build

# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

### Description

Similarly to npm pre- post- hooks, this support allows performing operations on the package post piral build

### Remarks

Creating PR for early feedback. These hooks help support our use case where we need to run some arbitrary scripts post `piral build`. We acknowledge that we might be to got this to work with wrapping `piral build` in a `build` script and use `postbuild`, though we can't achieve this behavior when building the emulator because it the output is already a tarball package.