### PR TITLE
add mechanism to inject emulator piletApi config

### DIFF
--- a/docs/specs/cli-specification.md
+++ b/docs/specs/cli-specification.md
@@ -63,7 +63,7 @@ For running the Piral instance in emulation mode, the set of relevant environmen
 | Environment Variable  | Purpose                             | Example            |
 |:----------------------|:------------------------------------|:-------------------|
 | `NODE_ENV`            | Indicate the target environment.    | `development`      |
-| `DEBUG_PILET`         | Injects pilet from development API. | `/$pilet-api`      |
+| `DEBUG_PILET`         | Indicate emulator environment.      | `on`               |
 | `DEBUG_PIRAL`         | Provides debug API for inspection.  | `1.0`              |
 | `SHARED_DEPENDENCIES` | Allow exposing shared dependencies. | `react,react-dom`  |
 

--- a/src/framework/piral-core/src/helpers.test.tsx
+++ b/src/framework/piral-core/src/helpers.test.tsx
@@ -194,7 +194,7 @@ describe('Piral-Core helpers module', () => {
     const wasUndefined = process.env.DEBUG_PILET === undefined;
 
     // Arrange
-    process.env.DEBUG_PILET = 'localhost:1234';
+    process.env.DEBUG_PILET = 'on';
     const setupMock = jest.fn();
     window.fetch = jest.fn((_, options) =>
       Promise.resolve({

--- a/src/framework/piral-core/src/helpers.tsx
+++ b/src/framework/piral-core/src/helpers.tsx
@@ -136,8 +136,8 @@ export function createPiletOptions({
 
       // if we run against the debug pilet API (emulator build only)
       if (process.env.DEBUG_PILET !== undefined) {
-        // the DEBUG_PILET env should point to an API address used as a proxy
-        const piletApi = process.env.DEBUG_PILET;
+        // the window['dbg:pilet-api'] should point to an API address used as a proxy, fall back to '/$pilet-api' if unavailable
+        const piletApi = window['dbg:pilet-api'] || '/$pilet-api';
         // either take a full URI or make it an absolute path relative to the current origin
         const initialTarget = /^https?:/.test(piletApi)
           ? piletApi

--- a/src/tooling/piral-cli/src/common/envs.test.ts
+++ b/src/tooling/piral-cli/src/common/envs.test.ts
@@ -33,7 +33,7 @@ describe('Environment Module', () => {
 
   it('setStandardEnvs respects a given pilet by setting the right env', () => {
     setStandardEnvs({ debugPilet: true, root });
-    expect(process.env.DEBUG_PILET).toBe('/$pilet-api');
+    expect(process.env.DEBUG_PILET).toBe('on');
     expect(process.env.SHARED_DEPENDENCIES).toBe('');
   });
 

--- a/src/tooling/piral-cli/src/common/envs.ts
+++ b/src/tooling/piral-cli/src/common/envs.ts
@@ -32,7 +32,7 @@ export function setStandardEnvs(options: StandardEnvProps) {
   }
 
   if (options.debugPilet) {
-    process.env.DEBUG_PILET = config.piletApi;
+    process.env.DEBUG_PILET = 'on';
   } else {
     delete process.env.DEBUG_PILET;
   }

--- a/src/tooling/piral-cli/src/injectors/pilet.ts
+++ b/src/tooling/piral-cli/src/injectors/pilet.ts
@@ -11,8 +11,6 @@ interface Pilet {
   requireRef?: string;
 }
 
-type Protocol = 'https' | 'http';
-
 export interface PiletInjectorConfig extends KrasInjectorConfig {
   pilets: Array<Pilet>;
   api: string;
@@ -21,13 +19,11 @@ export interface PiletInjectorConfig extends KrasInjectorConfig {
 
 export default class PiletInjector implements KrasInjector {
   public config: PiletInjectorConfig;
-  private port: number;
-  private protocol: Protocol;
+  private piletApi: string;
 
   constructor(options: PiletInjectorConfig, config: KrasConfiguration, core: EventEmitter) {
     this.config = options;
-    this.port = config.port;
-    this.protocol = config.ssl ? 'https' : 'http';
+    this.piletApi = `${config.ssl ? 'https' : 'http'}://localhost:${config.port}${config.api}`;
     const { pilets, api } = options;
     const cbs = {};
 
@@ -78,7 +74,7 @@ export default class PiletInjector implements KrasInjector {
     return {
       name: def.name,
       version: def.version,
-      link: `${this.protocol}://localhost:${this.port}${api}/${index}/${file}`,
+      link: `${this.piletApi}/${index}/${file}`,
       hash: bundler.bundle.hash,
       requireRef,
       noCache: true,
@@ -136,6 +132,18 @@ export default class PiletInjector implements KrasInjector {
     }
   }
 
+  sendIndexFile(target: string, url: string): KrasResponse {
+    const indexHtml = readFileSync(target, 'utf8');
+    
+    // mechanism to inject server side debug piletApi config into piral emulator
+    const windowInjectionScript = `window['dbg:pilet-api'] = '${this.piletApi}';`;
+    const findStr = `<script`;
+    const replaceStr = `<script>/* Pilet Debugging Emulator Config Injection */${windowInjectionScript}</script><script`;
+    const content = indexHtml.replace(`${findStr}`, `${replaceStr}`);
+
+    return this.sendContent(content, mime.getType(target), url);
+  }
+
   handle(req: KrasRequest): KrasResponse {
     const { app, api } = this.config;
     const path = req.url.substr(1).split('?')[0];
@@ -144,6 +152,9 @@ export default class PiletInjector implements KrasInjector {
       const target = join(app, path);
 
       if (existsSync(target) && statSync(target).isFile()) {
+        if (req.url === '/index.html') {
+          return this.sendIndexFile(target, req.url);
+        }
         return this.sendFile(target, req.url);
       } else if (req.url !== '/index.html') {
         return this.handle({


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

### Description

The emulator package is built and package for `pilet debug` to serve. It has a limitation that all `process.env.*` options are processed and replaced during build time. 

One issue we ran into was that `initialTarget` $pilet-api is set via `process.env.DEBUG_PILET`, if we were to set this to an absolute path "http://localhost:3000/$pilet-api", we would force all pilet development to use http protocol and port 3000.

We're crossing the boundary here for development purpose and would like to be able to dynamically (and automatically) provide the config options from emulator server. 

### Remarks

For more context, see previous PR #280 
