### PR TITLE
manually construct value for piletApi

### DIFF
--- a/src/tooling/piral-cli/src/injectors/pilet.ts
+++ b/src/tooling/piral-cli/src/injectors/pilet.ts
@@ -11,8 +11,6 @@ interface Pilet {
   requireRef?: string;
 }
 
-type Protocol = 'https' | 'http';
-
 export interface PiletInjectorConfig extends KrasInjectorConfig {
   pilets: Array<Pilet>;
   api: string;
@@ -21,13 +19,14 @@ export interface PiletInjectorConfig extends KrasInjectorConfig {
 
 export default class PiletInjector implements KrasInjector {
   public config: PiletInjectorConfig;
-  private port: number;
-  private protocol: Protocol;
+  private piletApi: string;
 
   constructor(options: PiletInjectorConfig, config: KrasConfiguration, core: EventEmitter) {
     this.config = options;
-    this.port = config.port;
-    this.protocol = config.ssl ? 'https' : 'http';
+    // either take a full URI or make it an absolute path relative to the current origin
+    this.piletApi = /^https?:/.test(options.api)
+      ? options.api
+      : `${config.ssl ? 'https' : 'http'}://localhost:${config.port}${options.api}`;
     const { pilets, api } = options;
     const cbs = {};
 
@@ -78,7 +77,7 @@ export default class PiletInjector implements KrasInjector {
     return {
       name: def.name,
       version: def.version,
-      link: `${this.protocol}://localhost:${this.port}${api}/${index}/${file}`,
+      link: `${this.piletApi}/${index}/${file}`,
       hash: bundler.bundle.hash,
       requireRef,
       noCache: true,
@@ -140,7 +139,7 @@ export default class PiletInjector implements KrasInjector {
     const indexHtml = readFileSync(target, 'utf8');
     
     // mechanism to inject server side debug piletApi config into piral emulator
-    const windowInjectionScript = `window['dbg:pilet-api'] = '${this.protocol}://localhost:${this.port}/$pilet-api';`;
+    const windowInjectionScript = `window['dbg:pilet-api'] = '${this.piletApi}';`;
     const findStr = `<script`;
     const replaceStr = `<script>/* Pilet Debugging Emulator Config Injection */${windowInjectionScript}</script><script`;
     const content = indexHtml.replace(`${findStr}`, `${replaceStr}`);

--- a/src/tooling/piral-cli/src/injectors/pilet.ts
+++ b/src/tooling/piral-cli/src/injectors/pilet.ts
@@ -11,6 +11,8 @@ interface Pilet {
   requireRef?: string;
 }
 
+type Protocol = 'https' | 'http';
+
 export interface PiletInjectorConfig extends KrasInjectorConfig {
   pilets: Array<Pilet>;
   api: string;
@@ -19,11 +21,13 @@ export interface PiletInjectorConfig extends KrasInjectorConfig {
 
 export default class PiletInjector implements KrasInjector {
   public config: PiletInjectorConfig;
-  private piletApi: string;
+  private port: number;
+  private protocol: Protocol;
 
   constructor(options: PiletInjectorConfig, config: KrasConfiguration, core: EventEmitter) {
     this.config = options;
-    this.piletApi = `${config.ssl ? 'https' : 'http'}://localhost:${config.port}${config.api}`;
+    this.port = config.port;
+    this.protocol = config.ssl ? 'https' : 'http';
     const { pilets, api } = options;
     const cbs = {};
 
@@ -74,7 +78,7 @@ export default class PiletInjector implements KrasInjector {
     return {
       name: def.name,
       version: def.version,
-      link: `${this.piletApi}/${index}/${file}`,
+      link: `${this.protocol}://localhost:${this.port}${api}/${index}/${file}`,
       hash: bundler.bundle.hash,
       requireRef,
       noCache: true,
@@ -136,7 +140,7 @@ export default class PiletInjector implements KrasInjector {
     const indexHtml = readFileSync(target, 'utf8');
     
     // mechanism to inject server side debug piletApi config into piral emulator
-    const windowInjectionScript = `window['dbg:pilet-api'] = '${this.piletApi}';`;
+    const windowInjectionScript = `window['dbg:pilet-api'] = '${this.protocol}://localhost:${this.port}/$pilet-api';`;
     const findStr = `<script`;
     const replaceStr = `<script>/* Pilet Debugging Emulator Config Injection */${windowInjectionScript}</script><script`;
     const content = indexHtml.replace(`${findStr}`, `${replaceStr}`);


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

### Description

When `PiletInjector` is constructed, `config.api` is `/manage-mock-server` which is definitely not `/$pilet-api`

So we need to manually construct value for `window[dbg:pilet-api]`

### Remarks

[Optionally place any follow-up comments, remarks, observations, or notes here for future reference]
