### PR TITLE
#294: allow upload of any pilet size via piral-cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Documentation cleanup
 * Renamed `extendApi` to `plugins` (keeping `extendApi` as deprecated)
+* Fixed hidden publishing pilet size limit and improved logging of axios errors (#294)
 
 ## 0.11.8 (July 9, 2020)
 

--- a/src/tooling/piral-cli/src/common/http.ts
+++ b/src/tooling/piral-cli/src/common/http.ts
@@ -67,6 +67,7 @@ export function postFile(target: string, key: string, file: Buffer, ca?: Buffer)
         'user-agent': `piral-cli/http.node-${os}`,
       },
       httpsAgent,
+      maxContentLength: Infinity
     })
     .then(
       res => res.data || true,
@@ -77,6 +78,14 @@ export function postFile(target: string, key: string, file: Buffer, ca?: Buffer)
           const { data, statusText, status } = error.response;
           const message = getMessage(data);
           log('unsuccessfulHttpPost_0066', statusText, status, message || '');
+        } else if (error.isAxiosError) {
+          // axios initiated error: try to parse message from error object
+          let errorMessage: string = error.errno || 'Unknown Axios Error';
+          if (typeof error.toJSON === 'function') {
+            const errorObj: { message?: string } = error.toJSON();
+            errorMessage = errorObj?.message ?? errorMessage;
+          }
+          log('failedHttpPost_0065', errorMessage);
         } else if (error.request) {
           // The request was made but no response was received
           // `error.request` is an instance of XMLHttpRequest in the browser and an instance of


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

### Description

1. Pilets of any size can now be published via cli (assuming feed service does not reject it for size). This was an update to the axios request config in http.ts `postFile`

2. Attempt to parse error messages differently when `isAxiosError`. This allows the following message change when calling an un-reachable host:

```
[0000] Using feed service "https://feed-eng.apps.dapt.to/api/v1/pilet/dev".
🚨  [0065] Failed to upload via HTTP: getaddrinfo ENOTFOUND feed-eng.apps.dapt.to.
⚠️  [0062] Could not upload "my-pilet-1.0.4.tgz" to feed service.
🚨  [0064] Failed to upload some pilet(s)!
Codes Reference: https://docs.piral.io/code/search
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
