### PR TITLE
Add ability to set and retrieve state during login flow

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -88,7 +88,7 @@ Following is a short guide on how to make a valid Pull Request.
    project so that you can grab any changes and bring them into your local copy.
 
    ```sh
-   git remote add upstream git@github.com:smapiopt/piral.git
+   git remote add upstream git@github.com:smapiot/piral.git
    ```
 
    You now have two remotes for this project on disk:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fixed `addEventListener` usage for `piral-native`
 * Fixed vulnerable dependency (GHSA-w7rc-rwvf-8q5r)
 * Fixed vulnerable dependency (CVE-2020-7720)
+* Added ability to set and retrieve state when signing in using `piral-oidc` (#318)
 
 ## 0.12.0 (September 9, 2020)
 
@@ -21,7 +22,6 @@
 * Added more standard fields such as `description` to the emulator package
 * Added `import-map-webpack-plugin` to the `piral-cli-webpack`
 * Added more flexibility to the `piral declaration` command (#316)
-* Added ability to set and retrieve state when signing in using `piral-oidc`
 
 ## 0.11.8 (July 9, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Added more standard fields such as `description` to the emulator package
 * Added `import-map-webpack-plugin` to the `piral-cli-webpack`
 * Added more flexibility to the `piral declaration` command (#316)
+* Added ability to set and retrieve state when signing in using `piral-oidc`
 
 ## 0.11.8 (July 9, 2020)
 

--- a/src/plugins/piral-oidc/README.md
+++ b/src/plugins/piral-oidc/README.md
@@ -185,13 +185,6 @@ can no longer be referenced due to jumping between your app and the auth pages.
 // module oidc.ts
 import { setupOidcClient } from 'piral-oidc';
 
-declare module 'piral-oidc/lib/types' {
-  // this interface determines the state type on the redirect params
-  interface PiralCustomRedirectState {
-    finalRedirectUri: string;
-  }
-}
-
 export const client = setupOidcClient({
   redirectUrl: location.origin + '/auth',
   postLogoutUrl: location.origin + '/logout',

--- a/src/plugins/piral-oidc/README.md
+++ b/src/plugins/piral-oidc/README.md
@@ -131,7 +131,7 @@ handle callbacks and routing for you. In order to use this, add a `appUrl` to th
 client configuration that points to your entry-point route, and then call `handleAuthentication()` in your index file.
 
 `handleAuthentication()` will return a promise that resolves to an `AuthenticationResult`
-When `result.isAuthenticated` is true, the application should call `render()`, when false, do nothing (this is a silent renew happening in the background).
+When `result.shouldRender` is true, the application should call `render()`, when false, do nothing (this is a silent renew happening in the background).
 
 If the promise rejects, it is advised that the error is logged to an external logging service, as this indicates a user that could not gain entry into the application. Afterwards, call `logout()` or prompt the user for the next action.
 
@@ -161,8 +161,8 @@ import { client } from './oidc';
 import { loggingService } from './your/logging/service';
 
 client.handleAuthentication()
-    .then(async ({ isAuthenticated }) => {
-        if (isAuthenticated) {
+    .then(async ({ shouldRender }) => {
+        if (shouldRender) {
             const render = await import('./app');
             render();
         }
@@ -206,10 +206,10 @@ export const client = setupOidcClient({
 import { client } from './oidc';
 
 client.handleAuthentication()
-  .then(async ({ isAuthenticated, state }) => {
+  .then(async ({ shouldRender, state }) => {
     if (state?.finalRedirectUri) {
       location.href = state.finalRedirectUri;
-    } else if (isAuthenticated) {
+    } else if (shouldRender) {
       const render = await import('./app');
       render();
     }

--- a/src/plugins/piral-oidc/src/setup.test.ts
+++ b/src/plugins/piral-oidc/src/setup.test.ts
@@ -205,7 +205,7 @@ describe('Piral-Oidc setup module', () => {
       //@ts-ignore
       window.location = new URL(redirectUri);
       expect(mockSigninSilentCallback).toBeCalledTimes(0);
-      const shouldRender = await client.handleAuthentication();
+      const { shouldRender } = await client.handleAuthentication();
       expect(mockSigninSilentCallback).toBeCalledTimes(1);
       expect(mockSigninCallback).toBeCalledTimes(0);
       expect(shouldRender).toBe(false);
@@ -216,7 +216,7 @@ describe('Piral-Oidc setup module', () => {
       //@ts-ignore
       window.location = new URL(redirectUri);
       expect(mockSigninCallback).toBeCalledTimes(0);
-      const shouldRender = await client.handleAuthentication();
+      const { shouldRender } = await client.handleAuthentication();
       expect(mockSigninSilentCallback).toBeCalledTimes(0);
       expect(mockSigninCallback).toBeCalledTimes(1);
       expect(shouldRender).toBe(false);
@@ -243,7 +243,7 @@ describe('Piral-Oidc setup module', () => {
       //@ts-ignore
       window.location = url;
       expect(window.location.href).not.toBe(appUri);
-      const shouldRender = await secondClient.handleAuthentication();
+      const { shouldRender } = await secondClient.handleAuthentication();
       expect(window.location.href).not.toBe(appUri);
       expect(shouldRender).toBe(true);
     });
@@ -252,7 +252,7 @@ describe('Piral-Oidc setup module', () => {
       const url = new URL(appUri);
       //@ts-ignore
       window.location = url;
-      const shouldRender = await client.handleAuthentication();
+      const { shouldRender } = await client.handleAuthentication();
       expect(shouldRender).toBe(true);
     });
 
@@ -262,7 +262,7 @@ describe('Piral-Oidc setup module', () => {
       //@ts-ignore
       window.location = url;
       expect(mockSigninRedirect).toBeCalledTimes(0);
-      const shouldRender = await client.handleAuthentication();
+      const { shouldRender } = await client.handleAuthentication();
       expect(mockSigninRedirect).toBeCalledTimes(1);
       expect(shouldRender).toBe(false);
     });

--- a/src/plugins/piral-oidc/src/setup.ts
+++ b/src/plugins/piral-oidc/src/setup.ts
@@ -128,7 +128,7 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
           return reject(new OidcError(OidcErrorType.oidcCallback, e));
         }
         return resolve({
-            isAuthenticated: false,
+            shouldRender: false,
             state: user?.state
         });
       }
@@ -148,15 +148,15 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
           Log.debug(`Redirecting to ${appUri} due to appUri being configured.`);
           window.location.href = appUri;
           return resolve({
-              isAuthenticated: false,
-              state: user?.state
+            shouldRender: false,
+            state: user?.state
           });
         }
 
         /* If appUri is not configured, we let the user decide what to do after getting a session. */
         return resolve({
-            isAuthenticated: true,
-            state: user?.state
+          shouldRender: true,
+          state: user?.state
         });
       }
 
@@ -168,7 +168,7 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
       return retrieveToken()
         .then((token) => {
           if (token) {
-            return resolve({ isAuthenticated: true });
+            return resolve({ shouldRender: true });
           } else {
             /* We should never get into this state, retrieveToken() should reject if there is no token */
             return reject(new OidcError(OidcErrorType.invalidToken));
@@ -185,7 +185,7 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
              * to the user's configured redirectUri.
              */
             await userManager.signinRedirect(signInRedirectParams);
-            return resolve({ isAuthenticated: false });
+            return resolve({ shouldRender: false });
           }
 
           /*

--- a/src/plugins/piral-oidc/src/setup.ts
+++ b/src/plugins/piral-oidc/src/setup.ts
@@ -1,6 +1,6 @@
-import { UserManager, Log } from 'oidc-client';
+import { User, UserManager, Log } from 'oidc-client';
 import { OidcError } from './OidcError';
-import { OidcConfig, OidcClient, OidcProfile, OidcErrorType, LogLevel } from './types';
+import { OidcConfig, OidcClient, OidcProfile, OidcErrorType, LogLevel, AuthenticationResult } from './types';
 
 const logLevelToOidcMap = {
   [LogLevel.none]: 0,
@@ -28,6 +28,7 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
     clientSecret,
     identityProviderUri,
     redirectUri = `${location.origin}/auth`,
+    signInRedirectParams,
     postLogoutRedirectUri = location.origin,
     responseType,
     scopes,
@@ -107,8 +108,10 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
     });
   };
 
-  const handleAuthentication = (): Promise<boolean> =>
+  const handleAuthentication = (): Promise<AuthenticationResult> =>
     new Promise(async (resolve, reject) => {
+      /** The user that is resolved when finishing the callback  */
+      let user: User;
       if (
         (doesWindowLocationMatch(userManager.settings.silent_redirect_uri) ||
           doesWindowLocationMatch(userManager.settings.popup_redirect_uri)) &&
@@ -120,16 +123,19 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
          * to update the parent. This is usually due to a timeout from a network error.
          */
         try {
-          await userManager.signinSilentCallback();
+          user = await userManager.signinSilentCallback();
         } catch (e) {
           return reject(new OidcError(OidcErrorType.oidcCallback, e));
         }
-        return resolve(false);
+        return resolve({
+            isAuthenticated: false,
+            state: user?.state
+        });
       }
 
       if (doesWindowLocationMatch(userManager.settings.redirect_uri) && isMainWindow()) {
         try {
-          await userManager.signinCallback();
+          user = await userManager.signinCallback();
         } catch (e) {
           /*
            * Failing to handle a sign-in callback is non-recoverable. The user is expected to call `logout()`, after
@@ -141,11 +147,17 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
         if (appUri) {
           Log.debug(`Redirecting to ${appUri} due to appUri being configured.`);
           window.location.href = appUri;
-          return resolve(false);
+          return resolve({
+              isAuthenticated: false,
+              state: user?.state
+          });
         }
 
         /* If appUri is not configured, we let the user decide what to do after getting a session. */
-        return resolve(true);
+        return resolve({
+            isAuthenticated: true,
+            state: user?.state
+        });
       }
 
       /*
@@ -156,9 +168,9 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
       return retrieveToken()
         .then((token) => {
           if (token) {
-            return resolve(true);
+            return resolve({ isAuthenticated: true });
           } else {
-            /* We should never get into this state, retireveToken() should reject if there is no token */
+            /* We should never get into this state, retrieveToken() should reject if there is no token */
             return reject(new OidcError(OidcErrorType.invalidToken));
           }
         })
@@ -172,8 +184,8 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
              * The resolve shouldn't matter, as `signinRedirect` will redirect the browser location
              * to the user's configured redirectUri.
              */
-            await userManager.signinRedirect();
-            return resolve(false);
+            await userManager.signinRedirect(signInRedirectParams);
+            return resolve({ isAuthenticated: false });
           }
 
           /*
@@ -187,7 +199,7 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
 
   return {
     login() {
-      return userManager.signinRedirect();
+      return userManager.signinRedirect(signInRedirectParams);
     },
     logout() {
       return userManager.signoutRedirect();
@@ -204,6 +216,6 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
       }
     },
     token: retrieveToken,
-    account: retrieveProfile,
+    account: retrieveProfile
   };
 }

--- a/src/plugins/piral-oidc/src/types.ts
+++ b/src/plugins/piral-oidc/src/types.ts
@@ -34,6 +34,10 @@ export interface OidcConfig {
    */
   redirectUri?: string;
   /**
+   * Query params that will be passed to the sign in redirect
+   */
+  signInRedirectParams?: SignInRedirectParams;
+  /**
    * The Uri to which the Identity provider should redirect
    * after a logout. By default the origin is used.
    */
@@ -112,6 +116,12 @@ export enum LogLevel {
 export interface PiralCustomOidcProfile {}
 
 /**
+ * This interface is used to determine the retained `state` value
+ * between the signin request and signin callback
+ */
+export interface PiralCustomRedirectState {}
+
+/**
  * The defined OIDC profile.
  */
 export type OidcProfile = PiralCustomOidcProfile & Profile;
@@ -144,7 +154,7 @@ export interface OidcClient {
    * an authentication failure manually, it is also advised to log this error to a logging service,
    * as no users will be be authorized to enter the application.
    */
-  handleAuthentication(): Promise<boolean>;
+  handleAuthentication(): Promise<AuthenticationResult>;
   /**
    * Retrieves the current user profile.
    */
@@ -214,4 +224,23 @@ export enum OidcErrorType {
  */
 export interface PiralOidcError extends Error {
   type: Readonly<OidcErrorType>;
+}
+
+export interface SignInRedirectParams {
+  /**
+   * Values used to maintain state between the sign in request and the callback.
+   * These will be available on the result from the handleAuthentication function
+   * successfully authenticates from a callback state.
+   */
+  state?: PiralCustomRedirectState;
+}
+
+/** Result that is returned from the handleAuthentication function */
+export interface AuthenticationResult {
+  /** Whether or not the authentication check was successful */
+  isAuthenticated: boolean;
+  /** The request state that is returned from any callbacks.
+   * This will only be populated if a callback method is called.
+   */
+  state?: PiralCustomRedirectState;
 }

--- a/src/plugins/piral-oidc/src/types.ts
+++ b/src/plugins/piral-oidc/src/types.ts
@@ -237,8 +237,8 @@ export interface SignInRedirectParams {
 
 /** Result that is returned from the handleAuthentication function */
 export interface AuthenticationResult {
-  /** Whether or not the authentication check was successful */
-  isAuthenticated: boolean;
+  /** Whether or not the application should be rendered */
+  shouldRender: boolean;
   /** The request state that is returned from any callbacks.
    * This will only be populated if a callback method is called.
    */

--- a/src/plugins/piral-oidc/src/types.ts
+++ b/src/plugins/piral-oidc/src/types.ts
@@ -116,12 +116,6 @@ export enum LogLevel {
 export interface PiralCustomOidcProfile {}
 
 /**
- * This interface is used to determine the retained `state` value
- * between the signin request and signin callback
- */
-export interface PiralCustomRedirectState {}
-
-/**
  * The defined OIDC profile.
  */
 export type OidcProfile = PiralCustomOidcProfile & Profile;
@@ -232,7 +226,7 @@ export interface SignInRedirectParams {
    * These will be available on the result from the handleAuthentication function
    * successfully authenticates from a callback state.
    */
-  state?: PiralCustomRedirectState;
+  state?: any;
 }
 
 /** Result that is returned from the handleAuthentication function */
@@ -242,5 +236,5 @@ export interface AuthenticationResult {
   /** The request state that is returned from any callbacks.
    * This will only be populated if a callback method is called.
    */
-  state?: PiralCustomRedirectState;
+  state?: any;
 }


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

### Description
This relates to #318
Added a new property `signInRedirectParams` to the setupOidcClient function which will be passed through to the signInRedirect call.

When performing a `signInCallback` on the oidc UserManager, this state will be available on the user. Since the only place this method is called is inside of the piral-oidc `handleAuthentication` function, I opted to just add the changes in there rather than its own function.

The signature of the `handleAuthentication` function has changed and is breaking to current users who rely on this returning a boolean.

### Remarks

This is more or less a proof of concept to how I got it working, I'm very open to feedback.

Originally I was unsure if all of this should be handled inside of the `handleAuthentication` function or not. The more I think on it I realize this should probably be in its own function. Something along the lines of `retrieveCallbackState` that is called after `handleAuthenticate` is called.