### PR TITLE
Adding `feed` parameter to `piral debug`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@
 
 * Fixed HMR in `piral-cli-webpack5` when running `piral debug`
 * Updated to use React 17 (#312)
+* Adding `feed` parameter to `piral debug`
 
 ## 0.12.4 (November 24, 2020)
 
 * Updated `dets` to use CLI logging levels
-* Extended all `register...` APIs to return disposers (#336) 
+* Extended all `register...` APIs to return disposers (#336)
 * Added `piral-cli-webpack5` to support bundling with Webpack 5 (#313)
 * Added the `packageOverrides` field to override *package.json* values of pilets (#330)
 * Added special tagged comments for additional modifications of the `PiletApi` (#332)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Fixed HMR in `piral-cli-webpack5` when running `piral debug`
 * Updated to use React 17 (#312)
-* Adding `feed` parameter to `piral debug`
+* Adding `feed` parameter to `pilet debug`
 
 ## 0.12.4 (November 24, 2020)
 

--- a/src/tooling/piral-cli/src/apps/debug-pilet.ts
+++ b/src/tooling/piral-cli/src/apps/debug-pilet.ts
@@ -66,6 +66,11 @@ export interface DebugPiletOptions {
   schemaVersion?: PiletSchemaVersion;
 
   /**
+   * The url of a pilet feed used to include locally missing pilets.
+   */
+  feed?: string
+
+  /**
    * Additional arguments for a specific bundler.
    */
   _?: Record<string, any>;
@@ -140,6 +145,7 @@ export async function debugPilet(baseDir = process.cwd(), options: DebugPiletOpt
     _ = {},
     bundlerName,
     app,
+    feed
   } = options;
   setLogLevel(logLevel);
   progress('Reading configuration ...');
@@ -236,6 +242,7 @@ export async function debugPilet(baseDir = process.cwd(), options: DebugPiletOpt
     app: appDir,
     handle: ['/', api],
     api,
+    feed
   };
 
   krasConfig.map['/'] = '';

--- a/src/tooling/piral-cli/src/commands.ts
+++ b/src/tooling/piral-cli/src/commands.ts
@@ -409,7 +409,9 @@ const allCommands: Array<ToolCommand<any>> = [
         .describe('app', 'Sets the name of the Piral instance.')
         .string('base')
         .default('base', process.cwd())
-        .describe('base', 'Sets the base directory. By default the current directory is used.');
+        .describe('base', 'Sets the base directory. By default the current directory is used.')
+        .string('feed')
+        .describe('feed', 'Sets the url of a pilet feed to be used to include locally missing pilets from.');
     },
     run(args) {
       return apps.debugPilet(args.base as string, {
@@ -422,6 +424,7 @@ const allCommands: Array<ToolCommand<any>> = [
         logLevel: args.logLevel as LogLevels,
         open: args.open as boolean,
         schemaVersion: args.schema as PiletSchemaVersion,
+        feed: args.feed as string,
         _: args,
       });
     },

--- a/src/tooling/piral-cli/src/injectors/pilet.test.ts
+++ b/src/tooling/piral-cli/src/injectors/pilet.test.ts
@@ -67,19 +67,19 @@ describe('Piral-CLI piral injector', () => {
     expect(res).not.toBeUndefined();
   });
 
-  it('PiletInjector can send reponse and fails with invalid path', () => {
+  it('PiletInjector can send response and fails with invalid path', async () => {
     // Arrange
     const core = new EventEmitter();
     const injector = new PiletInjector(optionsMock, configMock, core);
 
     // Act
-    const res = injector.sendResponse('some/nice/invalid/path', 'localhost:1234');
+    const res = await injector.sendResponse('some/nice/invalid/path', 'localhost:1234');
 
     // Assert
     expect(res).toBeUndefined();
   });
 
-  it('PiletInjector wont crash on mocked request', () => {
+  it('PiletInjector wont crash on mocked request', async () => {
     // Arrange
     const optionsMock = {
       pilets: [],
@@ -100,7 +100,7 @@ describe('Piral-CLI piral injector', () => {
     };
 
     // Act
-    const res = injector.handle(request);
+    const res = await injector.handle(request);
 
     // Assert
     expect(res).toBeUndefined();

--- a/src/tooling/piral-cli/src/injectors/pilet.ts
+++ b/src/tooling/piral-cli/src/injectors/pilet.ts
@@ -106,7 +106,11 @@ export default class PiletInjector implements KrasInjector {
     return JSON.stringify(mergedPilets);
   }
 
-  async loadRemoteFeed(feed: string): Promise<PiletMetaData[]> {
+  async loadRemoteFeed(feed?: string): Promise<PiletMetaData[]> {
+    if(!feed) {
+      return;
+    }
+
     try {
       const response = await axios.default.get<{ items?: PiletMetaData[] } | PiletMetaData[] | PiletMetaData>(feed)
 

--- a/src/tooling/piral-cli/src/injectors/pilet.ts
+++ b/src/tooling/piral-cli/src/injectors/pilet.ts
@@ -27,7 +27,6 @@ interface PiletMetaData {
 export default class PiletInjector implements KrasInjector {
   public config: PiletInjectorConfig;
   private piletApi: string;
-  private remotePiletsPromise: Promise<PiletMetaData[]>;
 
   constructor(options: PiletInjectorConfig, config: KrasConfiguration, core: EventEmitter) {
     this.config = options;


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

### Description

This PR adds a new parameter `feed` to the `pilet debug` CLI command.

This parameter allows specifying the URL of a pilet feed that can contain additional pilets which are not currently built from the developer machine.

This is especially helpful when different teams develop pilets. With this feature they can load the pilets of the other teams into their development experience, so they can much easier test and develop the usage of `Extensions` or even simple links between pages coming from different pilets.

The remote feed will only add pilets that are not provided by the local build. Pilets are identified by the `name`.

### Remarks

There were some failing tests already which are still failing with this PR. All other tests pass.