### PR TITLE
Add userStore as an optional OidcConfig property

### DIFF
--- a/src/plugins/piral-oidc/src/setup.ts
+++ b/src/plugins/piral-oidc/src/setup.ts
@@ -1,6 +1,6 @@
-import { User, UserManager, Log } from 'oidc-client';
+import { Log, User, UserManager } from 'oidc-client';
 import { OidcError } from './OidcError';
-import { OidcConfig, OidcClient, OidcProfile, OidcErrorType, LogLevel, AuthenticationResult } from './types';
+import { AuthenticationResult, LogLevel, OidcClient, OidcConfig, OidcErrorType, OidcProfile } from './types';
 
 const logLevelToOidcMap = {
   [LogLevel.none]: 0,
@@ -36,6 +36,7 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
     parentName,
     appUri,
     logLevel,
+    userStore
   } = config;
 
   const isMainWindow = () => (parentName ? parentName === window.parent?.name : window === window.top);
@@ -50,6 +51,7 @@ export function setupOidcClient(config: OidcConfig): OidcClient {
     client_secret: clientSecret,
     response_type: responseType,
     scope: scopes?.join(' '),
+    userStore: userStore
   });
 
   if (logLevel !== undefined) {

--- a/src/plugins/piral-oidc/src/types.ts
+++ b/src/plugins/piral-oidc/src/types.ts
@@ -1,5 +1,5 @@
 import type {} from 'piral-core';
-import type { Profile } from 'oidc-client';
+import type { Profile, StateStore } from 'oidc-client';
 
 /**
  * Available configuration options for the OpenID Connect plugin.
@@ -67,6 +67,12 @@ export interface OidcConfig {
    * Defaults to Log.DEBUG in development NODE_ENV.
    */
   logLevel?: LogLevel;
+
+  /**
+   * The store where user information will be placed after authentication succeeds
+   * This defaults to oidc-client's WebStorageStateStore, using sessionStorage as the internal store
+   */
+  userStore?: OidcStore;
 }
 
 /**
@@ -238,3 +244,6 @@ export interface AuthenticationResult {
    */
   state?: any;
 }
+
+/** An expected interface type for oidc-client to store its user state. */
+export interface OidcStore extends StateStore {}


### PR DESCRIPTION
# New Pull Request

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] All new and existing tests passed

## Type(s) of Changes
Simply added as passthrough `userStore` property to the piral-oidc `OidcConfig`

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first) #345 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

### Description
Described in #345 - Simply need to be able to override userStore in the UserManager constructor of the piral-oidc setup function.

### Remarks
Was unsure if re-using their storage interface is proper or if we should create a copy. 