### PR TITLE
fix #343

### DIFF
--- a/src/pages/docs/src/codegen/gen-plugins.js
+++ b/src/pages/docs/src/codegen/gen-plugins.js
@@ -42,7 +42,7 @@ module.exports = function () {
         '`',
         '<h2 id="installation">Installation</h2>',
         '<p>Add the plugin to your Piral instance by running:</p>',
-        `<pre><code>npm i ${packageJson.name}</code></pre>`,
+        `<pre><code>npm i ${plugin.name}</code></pre>`,
         peerDependencies,
         '<h2 id="description">Description</h2>',
         mdValue.substr(mdValue.indexOf('</h1>') + 5),


### PR DESCRIPTION
`packageJson` is the string path of the plug-in, my mistake! It is now fixed [#343](https://github.com/smapiot/piral/pull/343).

# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [ ] I have read the **CONTRIBUTING** document
- [ ] My code follows the code style of this project
- [ ] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

### Description

[Place a meaningful description here]

### Remarks

[Optionally place any follow-up comments, remarks, observations, or notes here for future reference]
