### PR TITLE
fix: 500 Bad request when pilet startup

### DIFF
--- a/src/tooling/piral-cli/src/injectors/pilet.ts
+++ b/src/tooling/piral-cli/src/injectors/pilet.ts
@@ -82,9 +82,6 @@ export default class PiletInjector implements KrasInjector {
     const { bundler, root, requireRef } = pilets[index];
     const def = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
     const file = bundler.bundle.name.replace(/^\//, '');
-    if (!file) {
-      return {};
-    }
     return {
       name: def.name,
       version: def.version,

--- a/src/tooling/piral-cli/src/injectors/pilet.ts
+++ b/src/tooling/piral-cli/src/injectors/pilet.ts
@@ -82,6 +82,9 @@ export default class PiletInjector implements KrasInjector {
     const { bundler, root, requireRef } = pilets[index];
     const def = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
     const file = bundler.bundle.name.replace(/^\//, '');
+    if (!file) {
+      return {};
+    }
     return {
       name: def.name,
       version: def.version,

--- a/src/tooling/piral-cli/src/injectors/pilet.ts
+++ b/src/tooling/piral-cli/src/injectors/pilet.ts
@@ -165,17 +165,18 @@ export default class PiletInjector implements KrasInjector {
     const pilet = pilets[+index];
     const bundler = pilet?.bundler;
 
-    await bundler?.ready();
-
     if (!path) {
+      await bundler?.ready();
       const content = await this.getMeta();
       return this.sendContent(content, 'application/json', url);
     } else {
-      const target = join(bundler.bundle.dir, rest.join('/'));
+      return bundler?.ready().then(() => {
+        const target = join(bundler.bundle.dir, rest.join('/'));
 
-      if (existsSync(target) && statSync(target).isFile()) {
-        return this.sendFile(target, url);
-      }
+        if (existsSync(target) && statSync(target).isFile()) {
+          return this.sendFile(target, url);
+        }
+      });
     }
   }
 

--- a/src/tooling/piral-cli/src/injectors/pilet.ts
+++ b/src/tooling/piral-cli/src/injectors/pilet.ts
@@ -163,22 +163,22 @@ export default class PiletInjector implements KrasInjector {
   }
 
   async sendResponse(path: string, url: string): Promise<KrasResult> {
+    const { pilets } = this.config;
+    const [index, ...rest] = path.split('/');
+    const pilet = pilets[+index];
+    const bundler = pilet?.bundler;
+
+    await bundler?.ready();
+
     if (!path) {
       const content = await this.getMeta();
       return this.sendContent(content, 'application/json', url);
     } else {
-      const { pilets } = this.config;
-      const [index, ...rest] = path.split('/');
-      const pilet = pilets[+index];
-      const bundler = pilet?.bundler;
+      const target = join(bundler.bundle.dir, rest.join('/'));
 
-      return bundler?.ready().then(() => {
-        const target = join(bundler.bundle.dir, rest.join('/'));
-
-        if (existsSync(target) && statSync(target).isFile()) {
-          return this.sendFile(target, url);
-        }
-      });
+      if (existsSync(target) && statSync(target).isFile()) {
+        return this.sendFile(target, url);
+      }
     }
   }
 


### PR DESCRIPTION
500 Bad request `localhost:1234/$pilet-api/0/`

Steps to reproduce: 
    1. `npm init piral-instance --target my-app -y`
    2. `yarn build` my-app
    3. `npm init pilet --target my-pilet --source ./my-app/dist/emulator/my-app-1.0.0.tgz -y`
    4. `yarn start -- --open` my-pilet
    5. Open the devtools of chrome browser immediately, you will see this 500 Bad request `localhost:1234/$pilet-api/0/`

# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [ ] My code follows the code style of this project
- [ ] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

### Description

This 500 Bad request will be caught by the Interceptors of the http client, where the error request will be redirected to the exception page, causing unexpected results.

### Remarks

![image](https://user-images.githubusercontent.com/5674761/102735080-6ede4c00-437c-11eb-934c-3f7d3191fe84.png)
