### PR TITLE
Debugging of integrated pilets

### DIFF
--- a/src/utilities/piral-debug-utils/src/emulator.ts
+++ b/src/utilities/piral-debug-utils/src/emulator.ts
@@ -60,10 +60,7 @@ export function withEmulatorPilets(requestPilets: PiletRequester, options: Emula
       })
       .then((pilets) =>
         appendix.then((debugPilets) => {
-          const piletNames = debugPilets.reduce((piletNames, debugPilet) => {
-            piletNames.push(debugPilet.name);
-            return piletNames;
-          }, []);
+          const piletNames = debugPilets.map(pilet => pilet.name);
           return pilets.filter((pilet) => piletNames.indexOf(pilet.name) === -1).concat(debugPilets);
         }),
       );

--- a/src/utilities/piral-debug-utils/src/emulator.ts
+++ b/src/utilities/piral-debug-utils/src/emulator.ts
@@ -58,6 +58,14 @@ export function withEmulatorPilets(requestPilets: PiletRequester, options: Emula
         console.error(`Requesting the pilets failed. We'll continue loading without pilets (DEBUG only).`, err);
         return [];
       })
-      .then((pilets) => appendix.then((debugPilets) => [...pilets, ...debugPilets]));
+      .then((pilets) =>
+        appendix.then((debugPilets) => {
+          const piletNames = debugPilets.reduce((piletNames, debugPilet) => {
+            piletNames.push(debugPilet.name);
+            return piletNames;
+          }, []);
+          return pilets.filter((pilet) => piletNames.indexOf(pilet.name) === -1).concat(debugPilets);
+        }),
+      );
   };
 }


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [ ] My code follows the code style of this project
- [ ] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

### Description

1. `sessionStorage.setItem('dbg:load-pilets', 'on');`
2. Distinguish between debugging and production:
```ts
const instance = createInstance({
...
  requestPilets() {
    if (process.env.DEBUG_PILET !== undefined) {
      // Debugging
      return fetch
        .create()('path/to/test/feed/service')
        .then((res) => res.json())
        .then((res) => res.items);
    } else {
      // Production
      return fetch
      .create()('path/to/production/feed/service')
      .then((res) => res.json())
      .then((res) => res.items);
    }
  },
...
});
```

In debug mode, replace the current pilet in the feed service (e.g. `path/to/test/feed/service`) with the local pilet.

### Remarks

[#344](https://github.com/smapiot/piral/pull/344)
