### PR TITLE
Detect yarn correctly in yarn only workspaces

### DIFF
--- a/src/tooling/piral-cli/src/common/npm.test.ts
+++ b/src/tooling/piral-cli/src/common/npm.test.ts
@@ -63,7 +63,7 @@ jest.mock('fs', () => ({
     return undefined;
   },
   exists: (file: string, cb: (status: boolean) => void) =>
-    cb(!file.endsWith('package.json') && !(specialCase && file.endsWith('lerna.json'))),
+    cb(!file.endsWith('package.json') && !(specialCase && (file.endsWith('lerna.json') || file.endsWith('yarn.lock')))),
   existsSync: (file: string) => {
     return true;
   },
@@ -220,7 +220,9 @@ describe('NPM Module', () => {
 
   it('detectYarn finds yarn.lock', async () => {
     await detectYarn('test').then((result) => expect(result).toBeTruthy());
+    specialCase = true;
     await detectYarn('toast').then((result) => expect(result).toBeFalsy());
+    specialCase = false;
   });
 
   it('uses npm to verify whether a particular package is included in monorepo package', async () => {

--- a/src/tooling/piral-cli/src/common/npm.ts
+++ b/src/tooling/piral-cli/src/common/npm.ts
@@ -32,12 +32,8 @@ export function detectNpm(root: string) {
   });
 }
 
-export function detectYarn(root: string) {
-  return new Promise((res) => {
-    access(resolve(root, 'yarn.lock'), constants.F_OK, (noYarnLock) => {
-      res(!noYarnLock);
-    });
-  });
+export async function detectYarn(root: string) {
+  return !!(await findFile(root, 'yarn.lock'));
 }
 
 export async function getLernaConfigPath(root: string) {


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

### Description

When using the piral-cli in yarn only workspaces (without Lerna), the CLI didn't correctly detect yarn, since the `yarn.lock` file will not be on the package level in that case but on the root of the workspace.
This fix is re-using the recursive file search that is also used for finding the `lerna.json` file already.
