### PR TITLE
Feature/blazor update

### DIFF
--- a/src/converters/piral-blazor/src/dependencies.ts
+++ b/src/converters/piral-blazor/src/dependencies.ts
@@ -9,14 +9,11 @@ export function createDependencyLoader(convert: ReturnType<typeof createConverte
       return dependency;
     },
     defineBlazorReferences(references) {
-      const load = () =>
-        Promise.all(
-          references.map((reference) =>
-            fetch(reference)
-              .then((res) => res.blob())
-              .then(addReference),
-          ),
-        );
+      const load = async () => {
+        for (const reference of references) {
+          await addReference(reference);
+        }
+      };
       let result = !lazy && convert.loader.then(load);
       dependency = () => result || (result = load());
     },

--- a/src/converters/piral-blazor/src/interop.ts
+++ b/src/converters/piral-blazor/src/interop.ts
@@ -10,15 +10,8 @@ export function deactivate(moduleName: string, referenceId: string) {
   return window['DotNet'].invokeMethodAsync<string>(coreLib, 'Deactivate', moduleName, referenceId);
 }
 
-export function addReference(blob: Blob) {
-  return new Promise((resolve) => {
-    const reader = new FileReader();
-    reader.onload = () => {
-      const data = reader.result.toString().replace(/^data:.+;base64,/, '');
-      window['DotNet'].invokeMethodAsync(coreLib, 'LoadComponentsFromLibrary', data).then(resolve);
-    };
-    reader.readAsDataURL(blob);
-  });
+export function addReference(url: string) {
+  return window['DotNet'].invokeMethodAsync(coreLib, 'LoadComponentsFromLibrary', url);
 }
 
 export function removeReference(name: string) {


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

### Description

Change for `piral-blazor`. Rather than defining Blazor references using blobs, we invoke the `LoadComponentsFromLibrary` with the URL as a parameter. This fixes an issue where blobs over 2MB would error out in .NET Blazor < 5.0. Read more [here](https://stackoverflow.com/questions/57938081) .

### Remarks

This change assumes the method signature of  `LoadComponentsFromLibrary` has been altered in `Piral.Blazor.Core`.
I opened a PR there: [Piral.Blazor#8](https://github.com/FlorianRappl/Piral.Blazor/pull/8)
