### PR TITLE
Set NODE_ENV to 'development' consistently for piral debug run

### DIFF
--- a/src/tooling/piral-cli-parcel/src/parcel/run-debug-mono-piral.ts
+++ b/src/tooling/piral-cli-parcel/src/parcel/run-debug-mono-piral.ts
@@ -13,7 +13,7 @@ async function run(root: string, piral: string, externals: Array<string>, entryF
   setStandardEnvs({
     piral,
     dependencies: externals,
-    production: true,
+    production: false,
     debugPiral: true,
     debugPilet: true,
     root,

--- a/src/tooling/piral-cli-webpack/src/webpack/run-debug-mono-piral.ts
+++ b/src/tooling/piral-cli-webpack/src/webpack/run-debug-mono-piral.ts
@@ -21,7 +21,7 @@ async function run(
   setStandardEnvs({
     piral,
     dependencies: externals,
-    production: true,
+    production: false,
     debugPiral: true,
     debugPilet: true,
     root,

--- a/src/tooling/piral-cli-webpack5/src/webpack/run-debug-mono-piral.ts
+++ b/src/tooling/piral-cli-webpack5/src/webpack/run-debug-mono-piral.ts
@@ -21,7 +21,7 @@ async function run(
   setStandardEnvs({
     piral,
     dependencies: externals,
-    production: true,
+    production: false,
     debugPiral: true,
     debugPilet: true,
     root,


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] All new and existing tests passed*

*  No _new_ breaking tests

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

### Description

When running piral debug (using webpack5) the following warning is displayed:
```
WARNING in DefinePlugin
Conflicting values for 'process.env.NODE_ENV'
```
This is caused by run-debug-mono-piral.ts setting process.env.NODE_ENV to 'production' (in line 24), but in line 37 it creates a baseConfig which sets mode to 'development', which makes webpack want to set NODE_ENV to development, ultimately causing the warning above.

This PR sets the NODE_ENV consistently to 'development'.
