### PR TITLE
Added optional parameters used by Angular `bootstrapModule` to `fromNg`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added runtime pilet metadata `basePath`
 * Added support for new debug utils (#397)
 * Added generic `piral-extension` web component for rendering extensions
+* Added option to run Angular without `zone.js` in `piral-ng`.
 
 ## 0.13.8 (September 10, 2021)
 

--- a/src/converters/piral-ng/README.md
+++ b/src/converters/piral-ng/README.md
@@ -37,6 +37,21 @@ export function setup(piral: PiletApi) {
 }
 ```
 
+Angular Options:
+
+You can optionally provide Options to `fromNg`, which are identical to those given to `bootstrapModule` during the Angular boot process. See https://angular.io/api/core/PlatformRef#bootstrapModule for possible values.
+
+This is mainly used to allow an Angular Pilet to run without `zone.js` as described [here](https://angular.io/guide/zone#noopzone).
+
+```ts
+import { PiletApi } from '<name-of-piral-instance>';
+import { AngularPage } from './AngularPage';
+
+export function setup(piral: PiletApi) {
+  piral.registerPage('/sample', piral.fromNg(AngularPage, { ngZone: 'noop' }));
+}
+```
+
 Within Angular components the Piral Angular extension component can be used by referring to `extension-component`, e.g.,
 
 ```html

--- a/src/converters/piral-ng/convert.ts
+++ b/src/converters/piral-ng/convert.ts
@@ -8,9 +8,9 @@ export interface NgConverter {
 export function createNgConverter(...params: Parameters<typeof createConverter>) {
   const convert = createConverter(...params);
   const Extension = convert.Extension;
-  const from: NgConverter = (component) => ({
+  const from: NgConverter = (component, opts) => ({
     type: 'html',
-    component: convert(component),
+    component: convert(component, opts),
   });
 
   return { from, Extension };

--- a/src/converters/piral-ng/src/converter.ts
+++ b/src/converters/piral-ng/src/converter.ts
@@ -3,6 +3,7 @@ import type { ForeignComponent, BaseComponentProps } from 'piral-core';
 import { createExtension } from './extension';
 import { enqueue } from './queue';
 import { bootstrap, NgModuleInt } from './bootstrap';
+import { NgOptions } from '.';
 
 let next = ~~(Math.random() * 10000);
 
@@ -20,20 +21,20 @@ export interface NgConverterOptions {
   /**
    * Defines the module options to apply when bootstrapping a component.
    */
-  moduleOptions?: Omit<NgModule, 'boostrap'>;
+  moduleOptions?: Omit<NgModule, 'bootstrap'>;
 }
 
 export function createConverter(config: NgConverterOptions = {}) {
   const { selectId = () => `ng-${next++}`, moduleOptions = {}, selector = 'extension-component' } = config;
   const Extension = createExtension(selector);
-  const convert = <TProps extends BaseComponentProps>(component: any): ForeignComponent<TProps> => {
+  const convert = <TProps extends BaseComponentProps>(component: any, opts?: NgOptions): ForeignComponent<TProps> => {
     let result: Promise<void | NgModuleInt> = Promise.resolve();
     let active = true;
 
     return {
       mount(el, props, ctx) {
         const id = selectId();
-        result = enqueue(() => active && bootstrap(ctx, props, component, el, id, moduleOptions, Extension));
+        result = enqueue(() => active && bootstrap(ctx, props, component, el, id, moduleOptions, Extension, opts));
       },
       unmount() {
         active = false;

--- a/src/converters/piral-ng/src/converter.ts
+++ b/src/converters/piral-ng/src/converter.ts
@@ -3,7 +3,7 @@ import type { ForeignComponent, BaseComponentProps } from 'piral-core';
 import { createExtension } from './extension';
 import { enqueue } from './queue';
 import { bootstrap, NgModuleInt } from './bootstrap';
-import { NgOptions } from '.';
+import { NgOptions } from './types';
 
 let next = ~~(Math.random() * 10000);
 

--- a/src/converters/piral-ng/src/create.ts
+++ b/src/converters/piral-ng/src/create.ts
@@ -13,14 +13,15 @@ export interface NgConfig extends NgConverterOptions {}
 export function createNgApi(config: NgConfig = {}): PiralPlugin<PiletNgApi> {
   return (context) => {
     const convert = createConverter(config);
-    context.converters.ng = ({ component }) => convert(component);
+    context.converters.ng = ({ component, opts }) => convert(component, opts);
 
     return {
       NgExtension: convert.Extension,
-      fromNg(component) {
+      fromNg(component, opts) {
         return {
           type: 'ng',
           component,
+          opts,
         };
       },
     };

--- a/src/converters/piral-ng/src/types.ts
+++ b/src/converters/piral-ng/src/types.ts
@@ -1,3 +1,4 @@
+import type { PlatformRef } from '@angular/core';
 import type { ForeignComponent } from 'piral-core';
 
 declare module 'piral-core/lib/types/custom' {
@@ -8,6 +9,8 @@ declare module 'piral-core/lib/types/custom' {
   }
 }
 
+export type NgOptions = Parameters<PlatformRef['bootstrapModule']>[1];
+
 export interface NgComponent {
   /**
    * The component root.
@@ -17,6 +20,8 @@ export interface NgComponent {
    * The type of the Angular component.
    */
   type: 'ng';
+
+  opts: NgOptions;
 }
 
 /**
@@ -28,7 +33,7 @@ export interface PiletNgApi {
    * @param component The component root.
    * @returns The Piral Ng component.
    */
-  fromNg(component: any): NgComponent;
+  fromNg(component: any, opts?: NgOptions): NgComponent;
   /**
    * Angular component for displaying extensions of the given name.
    */

--- a/src/converters/piral-ng/src/types.ts
+++ b/src/converters/piral-ng/src/types.ts
@@ -20,7 +20,12 @@ export interface NgComponent {
    * The type of the Angular component.
    */
   type: 'ng';
-
+  /**
+   * Options passed through to Angular `bootstrapModule`.
+   *
+   * Mainly to specify Noop Zone, but also includes compiler specific settings.
+   * See https://angular.io/api/core/PlatformRef#bootstrapModule for possible values.
+   */
   opts: NgOptions;
 }
 


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

### Description

Added optional parameters used by Angular `bootstrapModule` to `fromNg`. This is mainly used to allow the genrared Angular Pilet to run without `zone.js` by specifying `noop` zone. 

Also fixed typo regarding the string "bootstrap".

### Remarks

Not all tests pass on my machine (Windows 10, Node installation via installer, git bash), two tests regarding file paths in `src/tooling/piral-cli/src/common/npm.test.ts` fail in areas not affected by my changes. I suspect the tests werde never run on a native Windows machine without WSL. 