### PR TITLE
Updated PATH environment usage in Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.14.7 (tbd)
 
-- (...)
+- Updated `PATH` environment usage for child processes in Windows
 
 ## 0.14.6 (January 5, 2022)
 

--- a/src/tooling/piral-cli/src/common/scripts.ts
+++ b/src/tooling/piral-cli/src/common/scripts.ts
@@ -19,7 +19,6 @@ export function runScript(script: string, cwd = process.cwd(), output: NodeJS.Wr
   const sep = isWindows ? ';' : ':';
   const env = Object.assign({}, process.env);
 
-  env.PATH = `${bin}${sep}${env.PATH}`;
   log('generalDebug_0003', `Running "${script}" in "${cwd}" ("${bin}").`);
 
   if (isWindows) {
@@ -29,10 +28,12 @@ export function runScript(script: string, cwd = process.cwd(), output: NodeJS.Wr
       resolveWinPath('AppData', 'npm'),
       resolveWinPath('ProgramFiles', 'nodejs'),
       resolveWinPath('ProgramFiles(x86)', 'nodejs'),
-      ...env.PATH.split(';'),
+      ...env.Path.split(';'),
     ];
     env.PATH = newPaths.filter(Boolean).join(sep);
   }
+
+  env.PATH = `${bin}${sep}${env.PATH}`;
 
   return new Promise<void>((resolve, reject) => {
     const error = new MemoryStream();

--- a/src/tooling/piral-cli/src/common/scripts.ts
+++ b/src/tooling/piral-cli/src/common/scripts.ts
@@ -28,9 +28,9 @@ export function runScript(script: string, cwd = process.cwd(), output: NodeJS.Wr
       resolveWinPath('AppData', 'npm'),
       resolveWinPath('ProgramFiles', 'nodejs'),
       resolveWinPath('ProgramFiles(x86)', 'nodejs'),
-      ...env.Path.split(';'),
+      ...(env.Path || env.PATH || '').split(';'),
     ];
-    env.PATH = newPaths.filter(Boolean).join(sep);
+    env.PATH = newPaths.filter((path) => path && path.length > 0).join(sep);
   }
 
   env.PATH = `${bin}${sep}${env.PATH}`;


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

### Description

Resolving https://github.com/smapiot/piral/issues/192 when _nodejs/npm_ is installed on a custom user folder in a Windows environment.

### Remarks

In Windows, the code `const env = Object.assign({}, process.env);` does not set the `PATH` property on `env`.  It instead sets the `Path` property.  When subsequently using `env` option in child processes, _nodejs_ looks for a `PATH` property in the `env` option and uses that to locate the child process executable.
