### PR TITLE
add docs for blazor inside rush monorepo

### DIFF
--- a/docs/tutorials/23.2-monorepo-rush.md
+++ b/docs/tutorials/23.2-monorepo-rush.md
@@ -181,7 +181,7 @@ This will create js package for the blazor-pilet in the `packages\piral~\blazor-
     //...
   ]
 ```
-Since the new pilet is now located inside a folder depth of 3 we neet to set `projectFolderMaxDepth` inside `rush.json` to 3 like this:
+Since the new pilet is now located inside a folder depth of 3 we need to set `projectFolderMaxDepth` inside `rush.json` to 3 like this:
 ```json
   "projectFolderMinDepth": 2,
   "projectFolderMaxDepth": 3,

--- a/docs/tutorials/23.2-monorepo-rush.md
+++ b/docs/tutorials/23.2-monorepo-rush.md
@@ -79,7 +79,7 @@ Now we can run `rush build` to build all packages inside the monorepo. This comm
 
 To run the app-shell locally change into the app-shell folder and run `rushx start`. `rushx` is a way to run any of your scripts. So `rushx start` is basically the same as running `npm run start`. It's just shorter.
 
-## Add a Pilet
+## Add a pilet
 
 When adding more items to the monorepo it may make sense to follow a certain naming convention. As an example, we could suffix the pilets with `-pilet`. The exact convention is up to you - we will refer to the `-pilet` for our convention in this tutorial. Just make sure to stay consistent.
 
@@ -135,6 +135,63 @@ rush add -p react --dev
 
 After adding new packages you sometimes need to run `rush update --purge --full` to really update all cache files.
 :::
+
+## Add a blazor pilet
+Since blazor pilets need some more settings i'll cover them here in more depth. Let's start by adding a blazorwasm project. To do so run:
+```sh
+dotnet new blazorwasm -o .\packages\blazor-pilet
+```
+
+We should also add these 2 lines to the `.gitignore` file:
+```
+obj/
+bin/
+piral~/
+```
+
+We now have a standard blazorwasm project. to convert it into a pilet we need to go threw the following steps (you can read more about this in the [Piral.Blazor readme](https://github.com/smapiot/Piral.Blazor)):
+- Open `packages\blazor-pilet\blazor-pilet.csproj` and add the following inside the `PropertyGroup` section at the top:
+```xml
+<PiralInstance>../app-shell/dist/emulator/app-shell-1.0.0.tgz</PiralInstance>
+<Monorepo>enable</Monorepo>
+```
+- Install the `Piral.Blazor.Tools` and `Piral.Blazor.Utils` nuget packages
+- Rename Program.cs to Module.cs, and make sure to make the Main method an empty method.
+
+Now we need to prepare the piral instance to be able to include blazor pilets with these steps:
+- add the blazor dependency by running `rush add -p blazor` inside `packages\app-shell`
+- add the piral-blazor dependency by running `rush add -p piral-blazor` inside `packages\app-shell`
+- in `packages\app-shell\src\index.tsx` add the import `import { createBlazorApi } from 'piral-blazor';`
+- in `packages\app-shell\src\index.tsx` add `plugins: [createBlazorApi()], ` inside the `renderInstance` call
+- you might want tu run `rush update --full --purge` just to be sure
+- rebuild the app-shell via `rushx build`
+
+Now its time to build the pilet. cd into `packages\blazor-pilet` and run:
+```sh
+dotnet build
+```
+This will create js package for the blazor-pilet in the `packages\piral~\blazor-pilet` folder. To make Rush aware of the new pilet we need to add it to the `projects` setting inside the rush.json file like this:
+```json
+  "projects": [
+    //...
+    {
+      "packageName": "blazor-pilet",
+      "projectFolder": "packages/piral~/blazor-pilet"
+    }
+    //...
+  ]
+```
+Since the new pilet is now located inside a folder depth of 3 we neet to set `projectFolderMaxDepth` inside `rush.json` to 3 like this:
+```json
+  "projectFolderMinDepth": 2,
+  "projectFolderMaxDepth": 3,
+```
+Now run `rush update` to install the new pilet's dependencies.
+Finally cd into `packages\piral~\blazor-pilet` and run the new pilet via:
+```sh
+rushx start
+```
+
 
 ## Conclusion
 


### PR DESCRIPTION
Added docs on how to add a blazor pilet to a rush monorepo.
This documentation depends on this pr:
https://github.com/smapiot/Piral.Blazor/pull/69
So please only approve this after the other pr is approved.

Since i tested every step of the monorepo docs i have a test project on my pc. would you loke to host this in a repo inside smapiot?
If yes. how should i send it to you?