### PR TITLE
Release 0.14.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed handling of direct function exports in importmaps
 - Fixed usage of feed pilets when they are debugged locally
+- Added dependency map capability to debug utils
 
 ## 0.14.12 (February 21, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Piral Changelog
 
+## 0.14.13 (tbd)
+
+- Fixed handling of direct function exports in importmaps
+
 ## 0.14.12 (February 21, 2022)
 
 - Improved handling of `--bundler` when scaffolding

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.14.13 (tbd)
 
 - Fixed handling of direct function exports in importmaps
+- Fixed usage of feed pilets when they are debugged locally
 
 ## 0.14.12 (February 21, 2022)
 

--- a/src/framework/piral-base/src/system.ts
+++ b/src/framework/piral-base/src/system.ts
@@ -108,7 +108,13 @@ export function registerDependencies(modules: Record<string, any>) {
 export function registerModule(name: string, resolve: ModuleResolver) {
   System.register(name, [], (_exports) => ({
     execute() {
-      _exports(resolve());
+      const content = resolve();
+
+      if (content instanceof Promise) {
+        return content.then(_exports);
+      } else {
+        _exports(content);
+      }
     },
   }));
 }

--- a/src/framework/piral-base/src/system.ts
+++ b/src/framework/piral-base/src/system.ts
@@ -42,7 +42,7 @@ System.constructor.prototype.register = function (...args) {
         _export(...p);
       }
     };
-    getContent(exp, ctx);
+    return getContent(exp, ctx);
   });
 
   return systemRegister.apply(this, args);

--- a/src/framework/piral-base/src/system.ts
+++ b/src/framework/piral-base/src/system.ts
@@ -3,6 +3,51 @@ import 'systemjs/dist/extras/named-register.js';
 import type { PiletMetadataV2 } from './types';
 import { setBasePath } from './utils';
 
+function isPrimitiveExport(content: any) {
+  const type = typeof content;
+  return (
+    type === 'function' ||
+    type === 'number' ||
+    type === 'boolean' ||
+    type === 'symbol' ||
+    type === 'string' ||
+    type === 'bigint' ||
+    Array.isArray(content)
+  );
+}
+
+const systemRegister = System.constructor.prototype.register;
+
+System.constructor.prototype.register = function (...args) {
+  const getContent = args.pop() as System.DeclareFn;
+
+  args.push((_export, ctx) => {
+    const exp = (...p) => {
+      if (p.length === 1) {
+        const content = p[0];
+
+        if (content instanceof Promise) {
+          return content.then(exp);
+        } else if (isPrimitiveExport(content)) {
+          _export('__esModule', true);
+          _export('default', content);
+        } else if (content) {
+          _export(content);
+
+          if (typeof content === 'object' && !('default' in content)) {
+            _export('default', content);
+          }
+        }
+      } else {
+        _export(...p);
+      }
+    };
+    getContent(exp, ctx);
+  });
+
+  return systemRegister.apply(this, args);
+};
+
 export interface ModuleResolver {
   (): any;
 }
@@ -63,22 +108,7 @@ export function registerDependencies(modules: Record<string, any>) {
 export function registerModule(name: string, resolve: ModuleResolver) {
   System.register(name, [], (_exports) => ({
     execute() {
-      const content = resolve();
-
-      if (content instanceof Promise) {
-        return content.then(_exports);
-      } else {
-        _exports(content);
-
-        if (typeof content === 'function') {
-          _exports('__esModule', true);
-          _exports('default', content);
-        } else if (typeof content === 'object') {
-          if (content && !Array.isArray(content) && !('default' in content)) {
-            _exports('default', content);
-          }
-        }
-      }
+      _exports(resolve());
     },
   }));
 }

--- a/src/utilities/piral-debug-utils/src/emulator.ts
+++ b/src/utilities/piral-debug-utils/src/emulator.ts
@@ -57,6 +57,12 @@ export function withEmulatorPilets(requestPilets: PiletRequester, options: Emula
         console.error(`Requesting the pilets failed. We'll continue loading without pilets (DEBUG only).`, err);
         return [];
       })
-      .then((pilets) => appendix.then((debugPilets) => [...pilets, ...debugPilets]));
+      .then((pilets) =>
+        appendix.then((debugPilets) => {
+          const debugPiletNames = debugPilets.map((m) => m.name);
+          const feedPilets = pilets.filter((m) => !debugPiletNames.includes(m.name));
+          return [...feedPilets, ...debugPilets];
+        }),
+      );
   };
 }


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

### Description

This release fixes the handling of direct function exports (e.g., `export = function() { }`) in importmaps. In many cases, this would be already solved on the bundler level, but since we cannot trust this we need to be proactive here.

Also this release fixes the usage of feed pilets when they are debugged locally - e.g., if you have a layout pilet (named "layout-pilet") then you could still locally develop it - even though you'd include the feed with the layout pilet automatically.

Finally, this PR adds a dependency map capability to debug utils. With this info the Piral Inspector could show a nice graph display of the available pilets and their used dependencies.

### Remarks

Also adds a check action to the debug utils. This could be used by the Piral Inspector to have a more lightweight initial check.
