### PR TITLE
Feature/#546 add app name argument on new piral

### DIFF
--- a/docs/commands/new-piral.md
+++ b/docs/commands/new-piral.md
@@ -92,7 +92,7 @@ Sets the tag or version of the package to install. By default, this uses the ver
 
 - Aliases: `--piral-version`
 - Type: `string`
-- Default: `"0.14.30"`
+- Default: `"0.14.32"`
 
 ### `--force-overwrite`
 
@@ -153,3 +153,11 @@ Sets the base directory. By default the current directory is used.
 
 - Type: `string`
 - Default: `process.cwd()`
+
+### `--appName`
+
+Sets the name for the new Piral app.
+
+
+- Type: `string`
+- Default: `undefined`

--- a/docs/commands/new-piral.md
+++ b/docs/commands/new-piral.md
@@ -154,7 +154,7 @@ Sets the base directory. By default the current directory is used.
 - Type: `string`
 - Default: `process.cwd()`
 
-### `--appName`
+### `--app-name`
 
 Sets the name for the new Piral app.
 

--- a/src/tooling/piral-cli/src/apps/new-piral.test.ts
+++ b/src/tooling/piral-cli/src/apps/new-piral.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, existsSync } from 'fs';
+import { mkdtempSync, existsSync, readFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join, resolve } from 'path';
 import { newPiral } from './new-piral';
@@ -46,6 +46,25 @@ describe('New Piral Command', () => {
     expect(existsSync(resolve(dir, 'src/index.html'))).toBeTruthy();
     expect(existsSync(resolve(dir, 'src/mocks/backend.js'))).toBeTruthy();
     expect(existsSync(resolve(dir, '.npmrc'))).toBeFalsy();
+  });
+
+  it('scaffolding with custom app name works', async () => {
+    const dir = createTempDir();
+    await newPiral(dir, {
+      appName: 'test-name',
+      install: false,
+    });
+
+    expect(existsSync(resolve(dir, 'node_modules/piral/package.json'))).toBeTruthy();
+    expect(existsSync(resolve(dir, 'package.json'))).toBeTruthy();
+    expect(existsSync(resolve(dir, 'tsconfig.json'))).toBeTruthy();
+    expect(existsSync(resolve(dir, 'src/index.tsx'))).toBeTruthy();
+    expect(existsSync(resolve(dir, 'src/index.html'))).toBeTruthy();
+    expect(existsSync(resolve(dir, 'src/mocks/backend.js'))).toBeTruthy();
+    expect(existsSync(resolve(dir, '.npmrc'))).toBeFalsy();
+
+    const packageContent = await JSON.parse(readFileSync(`${dir}/package.json`, 'utf8'));
+    expect(packageContent.name).toBe('test-name');
   });
 
   it('scaffolding for piral-core works', async () => {

--- a/src/tooling/piral-cli/src/apps/new-piral.ts
+++ b/src/tooling/piral-cli/src/apps/new-piral.ts
@@ -86,6 +86,11 @@ export interface NewPiralOptions {
    * Places additional variables that should used when scaffolding.
    */
   variables?: Record<string, string>;
+
+  /**
+   * Sets new app name
+   */
+  appName?: string;
 }
 
 export const newPiralDefaults: NewPiralOptions = {
@@ -102,6 +107,7 @@ export const newPiralDefaults: NewPiralOptions = {
   npmClient: undefined,
   bundlerName: 'none',
   variables: {},
+  appName: undefined,
 };
 
 export async function newPiral(baseDir = process.cwd(), options: NewPiralOptions = {}) {
@@ -118,6 +124,7 @@ export async function newPiral(baseDir = process.cwd(), options: NewPiralOptions
     logLevel = newPiralDefaults.logLevel,
     bundlerName = newPiralDefaults.bundlerName,
     variables = newPiralDefaults.variables,
+    appName = newPiralDefaults.appName,
     npmClient: defaultNpmClient = newPiralDefaults.npmClient,
   } = options;
   const fullBase = resolve(process.cwd(), baseDir);
@@ -135,7 +142,7 @@ export async function newPiral(baseDir = process.cwd(), options: NewPiralOptions
   if (success) {
     const npmClient = await determineNpmClient(root, defaultNpmClient);
     const packageRef = combinePackageRef(framework, version, 'registry');
-    const projectName = basename(root);
+    const projectName = appName || basename(root);
 
     progress(`Creating a new Piral instance in %s ...`, root);
 

--- a/src/tooling/piral-cli/src/commands.ts
+++ b/src/tooling/piral-cli/src/commands.ts
@@ -317,9 +317,9 @@ const allCommands: Array<ToolCommand<any>> = [
         .string('base')
         .default('base', process.cwd())
         .describe('base', 'Sets the base directory. By default the current directory is used.')
-        .string('appName')
-        .describe('appName', 'Sets the name for the new Piral app.')
-        .default('appName', apps.newPiralDefaults.appName);
+        .string('app-name')
+        .describe('app-name', 'Sets the name for the new Piral app.')
+        .default('app-name', apps.newPiralDefaults.appName);
     },
     run(args) {
       return apps.newPiral(args.base as string, {
@@ -336,7 +336,7 @@ const allCommands: Array<ToolCommand<any>> = [
         npmClient: args['npm-client'] as NpmClientType,
         bundlerName: args.bundler as string,
         variables: args.vars as Record<string, string>,
-        appName: args.appName as string,
+        appName: args['app-name'] as string,
       });
     },
   },

--- a/src/tooling/piral-cli/src/commands.ts
+++ b/src/tooling/piral-cli/src/commands.ts
@@ -316,7 +316,10 @@ const allCommands: Array<ToolCommand<any>> = [
         .default('vars', apps.newPiralDefaults.variables)
         .string('base')
         .default('base', process.cwd())
-        .describe('base', 'Sets the base directory. By default the current directory is used.');
+        .describe('base', 'Sets the base directory. By default the current directory is used.')
+        .string('appName')
+        .describe('appName', 'Sets the name for the new Piral app.')
+        .default('appName', apps.newPiralDefaults.appName);
     },
     run(args) {
       return apps.newPiral(args.base as string, {
@@ -333,6 +336,7 @@ const allCommands: Array<ToolCommand<any>> = [
         npmClient: args['npm-client'] as NpmClientType,
         bundlerName: args.bundler as string,
         variables: args.vars as Record<string, string>,
+        appName: args.appName as string,
       });
     },
   },


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes

### Description

I added a `--appName` property to the `piral new` command in order to define the package name without having to edit the package.json manually afterwards. 

### Remarks

I've added a simple test that checks the package.json "name" content. As there are other tests checking for the scaffolding structure I decided to maintain those checks. 