### PR TITLE
Implemented #547: Add name argument to Pilet new. Changed appName arg…

### DIFF
--- a/docs/commands/new-pilet.md
+++ b/docs/commands/new-pilet.md
@@ -138,3 +138,11 @@ Sets the base directory. By default the current directory is used.
 
 - Type: `string`
 - Default: `process.cwd()`
+
+### `--name`
+
+Sets the name for the new Pilet.
+
+
+- Type: `string`
+- Default: `undefined`

--- a/docs/commands/new-piral.md
+++ b/docs/commands/new-piral.md
@@ -154,7 +154,7 @@ Sets the base directory. By default the current directory is used.
 - Type: `string`
 - Default: `process.cwd()`
 
-### `--app-name`
+### `--name`
 
 Sets the name for the new Piral app.
 

--- a/src/tooling/piral-cli/src/apps/new-pilet.test.ts
+++ b/src/tooling/piral-cli/src/apps/new-pilet.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, existsSync } from 'fs';
+import { mkdtempSync, existsSync, readFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join, resolve } from 'path';
 import { newPilet } from './new-pilet';
@@ -81,5 +81,22 @@ describe('New Pilet Command', () => {
     expect(existsSync(resolve(dir, 'tsconfig.json'))).toBeFalsy();
     expect(existsSync(resolve(dir, 'src/index.jsx'))).toBeTruthy();
     expect(existsSync(resolve(dir, '.npmrc'))).toBeFalsy();
+  });
+
+  it('should set pilet name if passed as argument', async () => {
+    const dir = createTempDir();
+    await newPilet(dir, {
+      install: false,
+      source: 'piral@latest',
+      name: 'testpiralname',
+    });
+    expect(existsSync(resolve(dir, 'node_modules/piral/package.json'))).toBeTruthy();
+    expect(existsSync(resolve(dir, 'package.json'))).toBeTruthy();
+    expect(existsSync(resolve(dir, 'tsconfig.json'))).toBeTruthy();
+    expect(existsSync(resolve(dir, 'src/index.tsx'))).toBeTruthy();
+    expect(existsSync(resolve(dir, '.npmrc'))).toBeFalsy();
+
+    const packageContent = await JSON.parse(readFileSync(`${dir}/package.json`, 'utf8'));
+    expect(packageContent.name).toBe('testpiralname');
   });
 });

--- a/src/tooling/piral-cli/src/apps/new-pilet.ts
+++ b/src/tooling/piral-cli/src/apps/new-pilet.ts
@@ -90,6 +90,11 @@ export interface NewPiletOptions {
    * Places additional variables that should used when scaffolding.
    */
   variables?: Record<string, string>;
+
+  /**
+   * Sets Pilet's name
+   */
+  name?: string;
 }
 
 export const newPiletDefaults: NewPiletOptions = {
@@ -104,6 +109,7 @@ export const newPiletDefaults: NewPiletOptions = {
   npmClient: undefined,
   bundlerName: 'none',
   variables: {},
+  name: undefined,
 };
 
 export async function newPilet(baseDir = process.cwd(), options: NewPiletOptions = {}) {
@@ -119,6 +125,7 @@ export async function newPilet(baseDir = process.cwd(), options: NewPiletOptions
     bundlerName = newPiletDefaults.bundlerName,
     variables = newPiletDefaults.variables,
     npmClient: defaultNpmClient = newPiletDefaults.npmClient,
+    name = newPiletDefaults.name,
   } = options;
   const fullBase = resolve(process.cwd(), baseDir);
   const root = resolve(fullBase, target);
@@ -129,7 +136,7 @@ export async function newPilet(baseDir = process.cwd(), options: NewPiletOptions
 
   if (success) {
     const npmClient = await determineNpmClient(root, defaultNpmClient);
-    const projectName = basename(root);
+    const projectName = name || basename(root);
 
     progress(`Scaffolding new pilet in %s ...`, root);
 

--- a/src/tooling/piral-cli/src/apps/new-piral.test.ts
+++ b/src/tooling/piral-cli/src/apps/new-piral.test.ts
@@ -51,7 +51,7 @@ describe('New Piral Command', () => {
   it('scaffolding with custom app name works', async () => {
     const dir = createTempDir();
     await newPiral(dir, {
-      appName: 'test-name',
+      name: 'test-name',
       install: false,
     });
 

--- a/src/tooling/piral-cli/src/apps/new-piral.ts
+++ b/src/tooling/piral-cli/src/apps/new-piral.ts
@@ -90,7 +90,7 @@ export interface NewPiralOptions {
   /**
    * Sets new app name
    */
-  appName?: string;
+  name?: string;
 }
 
 export const newPiralDefaults: NewPiralOptions = {
@@ -107,7 +107,7 @@ export const newPiralDefaults: NewPiralOptions = {
   npmClient: undefined,
   bundlerName: 'none',
   variables: {},
-  appName: undefined,
+  name: undefined,
 };
 
 export async function newPiral(baseDir = process.cwd(), options: NewPiralOptions = {}) {
@@ -124,7 +124,7 @@ export async function newPiral(baseDir = process.cwd(), options: NewPiralOptions
     logLevel = newPiralDefaults.logLevel,
     bundlerName = newPiralDefaults.bundlerName,
     variables = newPiralDefaults.variables,
-    appName = newPiralDefaults.appName,
+    name = newPiralDefaults.name,
     npmClient: defaultNpmClient = newPiralDefaults.npmClient,
   } = options;
   const fullBase = resolve(process.cwd(), baseDir);
@@ -142,7 +142,7 @@ export async function newPiral(baseDir = process.cwd(), options: NewPiralOptions
   if (success) {
     const npmClient = await determineNpmClient(root, defaultNpmClient);
     const packageRef = combinePackageRef(framework, version, 'registry');
-    const projectName = appName || basename(root);
+    const projectName = name || basename(root);
 
     progress(`Creating a new Piral instance in %s ...`, root);
 

--- a/src/tooling/piral-cli/src/commands.ts
+++ b/src/tooling/piral-cli/src/commands.ts
@@ -317,9 +317,9 @@ const allCommands: Array<ToolCommand<any>> = [
         .string('base')
         .default('base', process.cwd())
         .describe('base', 'Sets the base directory. By default the current directory is used.')
-        .string('app-name')
-        .describe('app-name', 'Sets the name for the new Piral app.')
-        .default('app-name', apps.newPiralDefaults.appName);
+        .string('name')
+        .describe('name', 'Sets the name for the new Piral app.')
+        .default('name', apps.newPiralDefaults.name);
     },
     run(args) {
       return apps.newPiral(args.base as string, {
@@ -336,7 +336,7 @@ const allCommands: Array<ToolCommand<any>> = [
         npmClient: args['npm-client'] as NpmClientType,
         bundlerName: args.bundler as string,
         variables: args.vars as Record<string, string>,
-        appName: args['app-name'] as string,
+        name: args['name'] as string,
       });
     },
   },
@@ -709,7 +709,10 @@ const allCommands: Array<ToolCommand<any>> = [
         .default('vars', apps.newPiletDefaults.variables)
         .string('base')
         .default('base', process.cwd())
-        .describe('base', 'Sets the base directory. By default the current directory is used.');
+        .describe('base', 'Sets the base directory. By default the current directory is used.')
+        .string('name')
+        .describe('name', 'Sets the name for the new Pilet.')
+        .default('name', apps.newPiletDefaults.name);
     },
     run(args) {
       return apps.newPilet(args.base as string, {
@@ -724,6 +727,7 @@ const allCommands: Array<ToolCommand<any>> = [
         npmClient: args['npm-client'] as NpmClientType,
         bundlerName: args.bundler as string,
         variables: args.vars as Record<string, string>,
+        name: args['name'] as string,
       });
     },
   },


### PR DESCRIPTION
Add "name" argument to Pilet new. Changed appName argument of `piral new` to have the same syntax.

# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes

### Description

Added argument "name" to `pilet new` command, used to assign the name to the package.json "project name". 
Also, I changed the `piral new --app-name` to have the same syntax: `piral new --name`.
