### PR TITLE
Release 0.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed issue of Angular components not being disposed (#561)
 - Improved loading of satellite dependencies in `piral-blazor`
 - Added `piral run-emulator` command to `piral-cli`
+- Added support for capabilities to `piral-blazor`
 
 ## 0.15.1 (November 25, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed import of common module in CommonJS build of `piral-ng`
 - Fixed issue of Angular components not being disposed (#561)
 - Improved loading of satellite dependencies in `piral-blazor`
+- Added `piral run-emulator` command to `piral-cli`
 
 ## 0.15.1 (November 25, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed import of common module in CommonJS build of `piral-ng`
 - Fixed issue of Angular components not being disposed (#561)
+- Improved loading of satellite dependencies in `piral-blazor`
 
 ## 0.15.1 (November 25, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Piral Changelog
 
+## 0.15.2 (tbd)
+
+- Fixed import of common module in CommonJS build of `piral-ng`
+
 ## 0.15.1 (November 25, 2022)
 
 - Fixed update of `piral-extension` web component inside foreign components

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.15.2 (tbd)
 
 - Fixed import of common module in CommonJS build of `piral-ng`
+- Fixed issue of Angular components not being disposed (#561)
 
 ## 0.15.1 (November 25, 2022)
 

--- a/docs/tutorials/20-migrate-app.md
+++ b/docs/tutorials/20-migrate-app.md
@@ -160,15 +160,20 @@ module.exports = {
       externals,
     }));
 
-    // Configure parcel-codegen-loader.
-    config.module.rules.unshift({
-      test: /\.codegen$/i,
-      use: [
-        {
-          loader: 'parcel-codegen-loader',
-        }
-      ]
-    });
+    const oneOfRule = config.module.rules.find(
+      (rule) => rule.oneOf !== undefined
+    );
+
+    if (oneOfRule) {
+      oneOfRule.oneOf.unshift({
+        test: /\.codegen$/i,
+        use: [
+          {
+            loader: "parcel-codegen-loader",
+          },
+        ],
+      });
+    }
 
     return config;
   },
@@ -176,7 +181,7 @@ module.exports = {
 };
 ```
 
-Of course, we could also switch over to the `piral-cli` using, e.g., `piral-cli-webpack` at this point. Nevertheless, having this just working without much effort is certainly a great stepping stone.
+Of course, we could also switch over to the `piral-cli` using, e.g., `piral-cli-webpack5` at this point. Nevertheless, having this just working without much effort is certainly a great stepping stone.
 
 ## What about Next.js
 

--- a/src/converters/piral-blazor/src/converter.ts
+++ b/src/converters/piral-blazor/src/converter.ts
@@ -1,7 +1,7 @@
 import type { BaseComponentProps, Disposable, ForeignComponent } from 'piral-core';
 import { addGlobalEventListeners, attachEvents, removeGlobalEventListeners } from './events';
 import { activate, deactivate, createBootLoader, reactivate, callNotifyLocationChanged } from './interop';
-import { BlazorOptions } from './types';
+import { BlazorDependencyLoader, BlazorOptions, BlazorRootConfig } from './types';
 import bootConfig from '../infra.codegen';
 
 const noop = () => {};
@@ -44,7 +44,7 @@ interface BlazorLocals {
   referenceId: string;
   node: HTMLElement;
   dispose(): void;
-  update(root: HTMLElement): void;
+  update(config: BlazorRootConfig): void;
   state: 'fresh' | 'mounted' | 'removed';
 }
 
@@ -53,7 +53,7 @@ export function createConverter(lazy: boolean) {
   let loader = !lazy && boot();
   let listener: Disposable = undefined;
 
-  const enqueueChange = (locals: BlazorLocals, update: (root: HTMLDivElement) => void) => {
+  const enqueueChange = (locals: BlazorLocals, update: (root: BlazorRootConfig) => void) => {
     if (locals.state === 'mounted') {
       loader.then(update);
     } else {
@@ -63,7 +63,7 @@ export function createConverter(lazy: boolean) {
 
   const convert = <TProps extends BaseComponentProps>(
     moduleName: string,
-    dependency: () => Promise<void>,
+    dependency: BlazorDependencyLoader,
     args: Record<string, any>,
     options?: BlazorOptions,
   ): ForeignComponent<TProps> => ({
@@ -94,17 +94,19 @@ export function createConverter(lazy: boolean) {
       );
 
       (loader || (loader = boot()))
-        .then((root) =>
-          dependency()
+        .then((config) =>
+          dependency(config)
             .then(() => activate(moduleName, props))
             .then((refId) => {
+              const [root] = config;
+
               if (locals.state === 'fresh') {
                 locals.id = refId;
                 locals.node = root.querySelector(`#${locals.id} > div`);
                 project(locals.node, el, options);
                 locals.state = 'mounted';
                 locals.referenceId = refId;
-                locals.update(root);
+                locals.update(config);
                 locals.update = noop;
               }
             }),
@@ -122,7 +124,7 @@ export function createConverter(lazy: boolean) {
       el.removeAttribute('data-blazor-pilet-root');
       locals.dispose();
 
-      enqueueChange(locals, (root) => {
+      enqueueChange(locals, ([root]) => {
         root.querySelector(`#${locals.id}`).appendChild(locals.node);
         deactivate(moduleName, locals.referenceId);
       });

--- a/src/converters/piral-blazor/src/converter.ts
+++ b/src/converters/piral-blazor/src/converter.ts
@@ -125,11 +125,11 @@ export function createConverter(lazy: boolean) {
       locals.dispose();
 
       enqueueChange(locals, ([root]) => {
-        root.querySelector(`#${locals.id}`).appendChild(locals.node);
+        root.querySelector(`#${locals.id}`)?.appendChild(locals.node);
         deactivate(moduleName, locals.referenceId);
+        el.innerHTML = '';
       });
 
-      el.innerHTML = '';
       locals.state = 'removed';
     },
   });

--- a/src/converters/piral-blazor/src/create.ts
+++ b/src/converters/piral-blazor/src/create.ts
@@ -25,12 +25,14 @@ export function createBlazorApi(config: BlazorConfig = {}): PiralPlugin<PiletBla
     context.converters.blazor = ({ moduleName, args, dependency, options }) =>
       convert(moduleName, dependency, args, options);
 
-    return () => {
+    return (_, meta) => {
       const loader = createDependencyLoader(convert, lazy);
       let options: BlazorOptions;
 
       return {
-        defineBlazorReferences: loader.defineBlazorReferences,
+        defineBlazorReferences(references) {
+          return loader.defineBlazorReferences(references, meta);
+        },
         defineBlazorOptions(blazorOptions: BlazorOptions) {
           options = blazorOptions;
         },

--- a/src/converters/piral-blazor/src/dependencies.ts
+++ b/src/converters/piral-blazor/src/dependencies.ts
@@ -1,53 +1,83 @@
-import { loadResource, loadResourceWithSymbol, unloadResource } from './interop';
+import type { PiletMetadata } from 'piral-core';
+import { loadBlazorPilet, loadResource, loadResourceWithSymbol, unloadBlazorPilet, unloadResource } from './interop';
 import type { createConverter } from './converter';
+import type { BlazorDependencyLoader, BlazorRootConfig } from './types';
 
 const loadedDependencies = (window.$blazorDependencies ??= []);
 
 export function createDependencyLoader(convert: ReturnType<typeof createConverter>, lazy = true) {
   const definedBlazorReferences: Array<string> = [];
-  let dependency: () => Promise<any>;
+  const loadedBlazorPilets: Array<string> = [];
+  let dependency: BlazorDependencyLoader;
 
   return {
     getDependency() {
       return dependency;
     },
-    defineBlazorReferences(references: Array<string>) {
-      const load = async () => {
-        for (const dllUrl of references) {
-          const dllName = dllUrl.substring(dllUrl.lastIndexOf('/') + 1);
+    defineBlazorReferences(references: Array<string>, meta: Partial<PiletMetadata> = {}) {
+      const load = async ([_, capabilities]: BlazorRootConfig) => {
+        if (capabilities.includes('load')) {
+          // new loading mechanism
 
-          if (dllUrl.endsWith('.dll')) {
-            const entry = loadedDependencies.find((m) => m.name === dllName);
+          const dependencies = references.filter((m) => m.endsWith('.dll'));
+          const dllUrl = dependencies.pop();
+          const piletName = dllUrl.substring(0, dllUrl.length - 4);
+          const piletPdb = `${piletName}.pdb`;
+          const pdbUrl = references.find((m) => m === piletPdb);
+          const id = Math.random().toString(26).substring(2);
 
-            if (entry) {
-              entry.count++;
-              await entry.promise;
-            } else {
-              const urlWithoutExtension = dllUrl.substring(0, dllUrl.length - 4);
-              const pdbName = `${urlWithoutExtension}.pdb`;
-              const pdbUrl = references.find((m) => m === pdbName);
-              const promise = pdbUrl ? loadResourceWithSymbol(dllUrl, pdbUrl) : loadResource(dllUrl);
+          await loadBlazorPilet(id, {
+            name: meta.name || '(unknown)',
+            version: meta.version || '0.0.0',
+            config: JSON.stringify(meta.config || {}),
+            baseUrl: meta.basePath || dllUrl.substring(0, dllUrl.lastIndexOf('/')).replace('/_framework/', '/'),
+            dependencies,
+            dllUrl,
+            pdbUrl,
+          });
 
-              loadedDependencies.push({
-                name: dllName,
-                url: dllUrl,
-                count: 1,
-                promise,
-              });
+          loadedBlazorPilets.push(id);
+        } else {
+          // old loading mechanism
 
-              await promise;
+          for (const dllUrl of references) {
+            const dllName = dllUrl.substring(dllUrl.lastIndexOf('/') + 1);
+
+            if (dllUrl.endsWith('.dll')) {
+              const entry = loadedDependencies.find((m) => m.name === dllName);
+
+              if (entry) {
+                entry.count++;
+                await entry.promise;
+              } else {
+                const urlWithoutExtension = dllUrl.substring(0, dllUrl.length - 4);
+                const pdbName = `${urlWithoutExtension}.pdb`;
+                const pdbUrl = references.find((m) => m === pdbName);
+                const promise = pdbUrl ? loadResourceWithSymbol(dllUrl, pdbUrl) : loadResource(dllUrl);
+
+                loadedDependencies.push({
+                  name: dllName,
+                  url: dllUrl,
+                  count: 1,
+                  promise,
+                });
+
+                await promise;
+              }
+
+              definedBlazorReferences.push(dllName);
             }
-
-            definedBlazorReferences.push(dllName);
           }
         }
       };
       let result = !lazy && convert.loader.then(load);
-      dependency = () => result || (result = load());
+      dependency = (config) => result || (result = load(config));
     },
     async releaseBlazorReferences() {
       const references = definedBlazorReferences.splice(0, definedBlazorReferences.length);
+      const ids = loadedBlazorPilets.splice(0, loadedBlazorPilets.length);
 
+      // old way of loading
       for (const reference of references) {
         const entry = loadedDependencies.find((m) => m.name === reference);
 
@@ -55,6 +85,11 @@ export function createDependencyLoader(convert: ReturnType<typeof createConverte
           loadedDependencies.splice(loadedDependencies.indexOf(entry), 1);
           await unloadResource(entry.url);
         }
+      }
+
+      // new way of loading
+      for (const id of ids) {
+        await unloadBlazorPilet(id);
       }
     },
   };

--- a/src/converters/piral-blazor/src/types.ts
+++ b/src/converters/piral-blazor/src/types.ts
@@ -1,10 +1,16 @@
 import type { ForeignComponent } from 'piral-core';
 
+export type BlazorRootConfig = [root: HTMLDivElement, capabilities: Array<string>];
+
+export interface BlazorDependencyLoader {
+  (config: BlazorRootConfig): Promise<void>;
+}
+
 declare global {
   interface Window {
     Blazor: any;
     DotNet: any;
-    $blazorLoader: Promise<HTMLDivElement>;
+    $blazorLoader: Promise<BlazorRootConfig>;
     $blazorDependencies: Array<{
       name: string;
       url: string;
@@ -45,7 +51,7 @@ export interface BlazorComponent {
    * An optional dependency that needs to load before
    * the component can be properly displayed.
    */
-  dependency?: () => Promise<void>;
+  dependency?: BlazorDependencyLoader;
   /**
    * The type of the Blazor component.
    */

--- a/src/converters/piral-blazor/src/types.ts
+++ b/src/converters/piral-blazor/src/types.ts
@@ -9,6 +9,7 @@ declare global {
       name: string;
       url: string;
       count: number;
+      promise: Promise<void>;
     }>;
   }
 }

--- a/src/converters/piral-ng/src/common/index.d.ts
+++ b/src/converters/piral-ng/src/common/index.d.ts
@@ -1,0 +1,1 @@
+export * from './public_api';

--- a/src/converters/piral-ng/src/common/ng-package.json
+++ b/src/converters/piral-ng/src/common/ng-package.json
@@ -2,7 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/main/src/ng-package.schema.json",
   "dest": "../../common",
   "assets": [
-    "index.d.ts"
+    "index.d.ts",
+    "piral-ng-common.js"
   ],
   "lib": {
     "entryFile": "./public_api.ts"

--- a/src/converters/piral-ng/src/common/ng-package.json
+++ b/src/converters/piral-ng/src/common/ng-package.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/ng-packagr/ng-packagr/main/src/ng-package.schema.json",
   "dest": "../../common",
+  "assets": [
+    "index.d.ts"
+  ],
   "lib": {
     "entryFile": "./public_api.ts"
    }

--- a/src/converters/piral-ng/src/common/package.json
+++ b/src/converters/piral-ng/src/common/package.json
@@ -4,6 +4,7 @@
   "description": "Common module for piral-ng.",
   "keywords": [],
   "author": "smapiot",
+  "main": "piral-ng-common.js",
   "homepage": "https://piral.io",
   "license": "MIT",
   "repository": {

--- a/src/converters/piral-ng/src/common/piral-ng-common.js
+++ b/src/converters/piral-ng/src/common/piral-ng-common.js
@@ -1,0 +1,3 @@
+exports.NgExtension = class {};
+exports.SharedModule = class {};
+exports.ResourceUrlPipe = class {};

--- a/src/converters/piral-ng/src/converter.ts
+++ b/src/converters/piral-ng/src/converter.ts
@@ -42,7 +42,7 @@ export function createConverter(_: NgConverterOptions = {}): NgConverter {
           }
 
           if (locals.active) {
-            bootstrap(registry.get(component), el, locals.props, ctx);
+            return await bootstrap(registry.get(component), el, locals.props, ctx);
           }
         }),
       );

--- a/src/tooling/piral-cli/src/apps/index.ts
+++ b/src/tooling/piral-cli/src/apps/index.ts
@@ -9,6 +9,7 @@ export * from './new-pilet';
 export * from './upgrade-pilet';
 export * from './add-piral-instance-pilet';
 export * from './remove-piral-instance-pilet';
+export * from './run-emulator-piral';
 export * from './debug-pilet';
 export * from './build-pilet';
 export * from './pack-pilet';

--- a/src/tooling/piral-cli/src/apps/run-emulator-piral.ts
+++ b/src/tooling/piral-cli/src/apps/run-emulator-piral.ts
@@ -1,0 +1,150 @@
+import { tmpdir } from 'os';
+import { mkdtemp } from 'fs';
+import { dirname, resolve } from 'path';
+import { readKrasConfig, krasrc, buildKrasWithCli } from 'kras';
+import { LogLevels, NpmClientType } from '../types';
+import {
+  config,
+  openBrowser,
+  notifyServerOnline,
+  setLogLevel,
+  progress,
+  log,
+  createInitialKrasConfig,
+  getAvailablePort,
+  installPiralInstance,
+  createFileIfNotExists,
+  ForceOverwrite,
+  findPiralInstance,
+} from '../common';
+
+export interface RunEmulatorPiralOptions {
+  /**
+   * Sets the log level to use (1-5).
+   */
+  logLevel?: LogLevels;
+
+  /**
+   * The name of the app shell emulator to use.
+   */
+  app?: string;
+
+  /**
+   * Sets if the (system default) browser should be auto-opened.
+   */
+  open?: boolean;
+
+  /**
+   * Sets the port to use for the debug server.
+   */
+  port?: number;
+
+  /**
+   * The URL of a pilet feed(s) used to include locally missing pilets.
+   */
+  feed?: string | Array<string>;
+
+  /**
+   * The npm client to be used when scaffolding.
+   * @example 'yarn'
+   */
+  npmClient?: NpmClientType;
+
+  /**
+   * The package registry to use for resolving the specified Piral app.
+   */
+  registry?: string;
+}
+
+export const runEmulatorPiralDefaults: RunEmulatorPiralOptions = {
+  logLevel: LogLevels.info,
+  open: config.openBrowser,
+  port: config.port,
+  registry: config.registry,
+  npmClient: undefined,
+};
+
+function createTempDir() {
+  return new Promise<string>((resolve, reject) =>
+    mkdtemp(tmpdir(), (err, dir) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(dir);
+      }
+    }),
+  );
+}
+
+export async function runEmulatorPiral(baseDir = process.cwd(), options: RunEmulatorPiralOptions = {}) {
+  const {
+    open = runEmulatorPiralDefaults.open,
+    port: originalPort = runEmulatorPiralDefaults.port,
+    logLevel = runEmulatorPiralDefaults.logLevel,
+    npmClient = runEmulatorPiralDefaults.npmClient,
+    registry = runEmulatorPiralDefaults.registry,
+    app,
+    feed,
+  } = options;
+  const publicUrl = '/';
+  const fullBase = resolve(process.cwd(), baseDir);
+  const baseMocks = resolve(fullBase, 'mocks');
+  setLogLevel(logLevel);
+
+  progress('Reading configuration ...');
+  const api = config.piletApi.replace(/^\/+/, '');
+
+  process.stderr.setMaxListeners(16);
+  process.stdout.setMaxListeners(16);
+  process.stdin.setMaxListeners(16);
+
+  const appRoot = await createTempDir();
+
+  if (registry !== runEmulatorPiralDefaults.registry) {
+    progress(`Setting up npm registry (%s) ...`, registry);
+
+    await createFileIfNotExists(
+      appRoot,
+      '.npmrc',
+      `registry=${registry}
+always-auth=true`,
+      ForceOverwrite.yes,
+    );
+  }
+
+  const [packageName] = await installPiralInstance(app, fullBase, appRoot, npmClient);
+  const piral = findPiralInstance(packageName, appRoot, originalPort);
+  const port = await getAvailablePort(piral.port);
+
+  const krasBaseConfig = resolve(fullBase, krasrc);
+  const krasRootConfig = resolve(appRoot, krasrc);
+  const initial = createInitialKrasConfig(baseMocks, [], { [api]: '' }, feed);
+  const required = {
+    injectors: {
+      piral: {
+        active: false,
+      },
+      pilet: {
+        active: true,
+        pilets: [],
+        app: dirname(piral.app),
+        publicUrl,
+        handle: ['/', api],
+        api,
+      },
+    },
+  };
+  const configs = [krasBaseConfig, krasRootConfig];
+  const krasConfig = readKrasConfig({ port, initial, required }, ...configs);
+
+  log('generalVerbose_0004', `Using kras with configuration: ${JSON.stringify(krasConfig, undefined, 2)}`);
+
+  const krasServer = buildKrasWithCli(krasConfig);
+  krasServer.setMaxListeners(16);
+  krasServer.removeAllListeners('open');
+  krasServer.on('open', notifyServerOnline(publicUrl, krasConfig.api));
+
+  await krasServer.start();
+  openBrowser(open, port, publicUrl, !!krasConfig.ssl);
+  await new Promise((resolve) => krasServer.on('close', resolve));
+}

--- a/src/tooling/piral-cli/src/commands.ts
+++ b/src/tooling/piral-cli/src/commands.ts
@@ -883,6 +883,53 @@ const allCommands: Array<ToolCommand<any>> = [
       });
     },
   },
+  {
+    name: 'run-emulator-piral',
+    alias: ['start-emulator-piral', 'dev-emulator-portal'],
+    description: 'Starts a Piral instance emulator.',
+    arguments: ['[source]'],
+    // "any" due to https://github.com/microsoft/TypeScript/issues/28663 [artifical N = 50]
+    flags(argv: any) {
+      return argv
+        .positional('source', {
+          type: 'string',
+          describe: 'Sets the source Piral instance emulator package name.',
+          default: apps.runEmulatorPiralDefaults.app,
+        })
+        .number('port')
+        .describe('port', 'Sets the port of the local development server.')
+        .default('port', apps.runEmulatorPiralDefaults.port)
+        .string('registry')
+        .describe('registry', 'Sets the package registry to use for resolving the emulator.')
+        .default('registry', apps.runEmulatorPiralDefaults.registry)
+        .alias('registry', 'package-registry')
+        .number('log-level')
+        .describe('log-level', 'Sets the log level to use (1-5).')
+        .default('log-level', apps.runEmulatorPiralDefaults.logLevel)
+        .choices('npm-client', clientTypeKeys)
+        .describe('npm-client', 'Sets the npm client to be used when installing the emulator.')
+        .default('npm-client', apps.runEmulatorPiralDefaults.npmClient)
+        .boolean('open')
+        .describe('open', 'Opens the Piral instance directly in the browser.')
+        .default('open', apps.runEmulatorPiralDefaults.open)
+        .string('feed')
+        .describe('feed', 'Sets the URL of a pilet feed for including remote pilets.')
+        .string('base')
+        .default('base', process.cwd())
+        .describe('base', 'Sets the base directory. By default the current directory is used.');
+    },
+    run(args) {
+      return apps.runEmulatorPiral(args.base as string, {
+        port: args.port as number,
+        app: args.source as string,
+        npmClient: args['npm-client'] as NpmClientType,
+        registry: args.registry as string,
+        logLevel: args['log-level'] as LogLevels,
+        open: args.open as boolean,
+        feed: args.feed as string,
+      });
+    },
+  },
 ];
 
 class Commands implements ListCommands {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6565,9 +6565,9 @@ decimal.js@^10.3.1:
   integrity sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==
 
 decode-uri-component@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
-  integrity sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
+  integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
 
 dedent@^0.7.0:
   version "0.7.0"


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes

### Description

Places a fix for the destruction of Angular components / render instances. Also adds a new command to the Piral CLI for running emulators without debugging a pilet. Finally, enhances `piral-blazor` to progressively support new features, starting with new pilet loading (starting with Piral.Blazor v4). 

### Remarks

In 0.15.3 we'll also add `custom-elements`, which will be supported by Piral.Blazor v4 from .NET 7 or higher.
