### PR TITLE
Fix #579 (piral-ng destroying all modules instead of only the intended one)

### DIFF
--- a/src/converters/piral-ng/src/startup.ts
+++ b/src/converters/piral-ng/src/startup.ts
@@ -1,8 +1,18 @@
 import type { ComponentContext } from 'piral-core';
 import type { NgOptions } from './types';
-import { enableProdMode, NgModuleRef, NgZone, PlatformRef } from '@angular/core';
+import {
+  createPlatformFactory,
+  enableProdMode,
+  NgModuleRef,
+  NgZone,
+  PlatformRef,
+  ɵALLOW_MULTIPLE_PLATFORMS as ALLOW_MULTIPLE_PLATFORMS,
+} from '@angular/core';
 import { APP_BASE_HREF } from '@angular/common';
-import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import {
+  ɵplatformCoreDynamic as platformCoreDynamic,
+  ɵINTERNAL_BROWSER_DYNAMIC_PLATFORM_PROVIDERS as INTERNAL_BROWSER_DYNAMIC_PLATFORM_PROVIDERS,
+} from '@angular/platform-browser-dynamic';
 import { getId, getNgVersion } from './utils';
 
 function getVersionHandler(versions: Record<string, () => void>) {
@@ -11,11 +21,19 @@ function getVersionHandler(versions: Record<string, () => void>) {
   return versions[version];
 }
 
+// Equivalent to platformBrowserDynamic, but with support for multiple platforms
+const customPlatformDynamicFactory = createPlatformFactory(platformCoreDynamic, 'piralDynamic', [
+  ...INTERNAL_BROWSER_DYNAMIC_PLATFORM_PROVIDERS,
+  {
+    provide: ALLOW_MULTIPLE_PLATFORMS,
+    useValue: true,
+  },
+]);
 const runningModules: Array<[any, NgModuleInt, PlatformRef]> = [];
 
 function startNew(BootstrapModule: any, context: ComponentContext, ngOptions?: NgOptions) {
   const path = context.publicPath || '/';
-  const platform = platformBrowserDynamic([
+  const platform = customPlatformDynamicFactory([
     { provide: 'Context', useValue: context },
     { provide: APP_BASE_HREF, useValue: path },
   ]);


### PR DESCRIPTION
## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

### Description

Implements the second solution as outlined in #579.

It makes use of some Angular internals similarly to how Angular does for SSR: https://github.com/angular/angular/blob/main/packages/platform-server/src/server.ts

### Remarks

My Angular knowledge is limited, but I tried my best at analyzing the issue and this solution.
Let me know if I've missed anything.

While relying on Angular internals is hacky, I don't really think there's a better fix for this issue.

Thanks for the great work on this framework :D