### PR TITLE
feat: #583 Added optional `assetBaseUrl` property in `PiletInjector` config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.15.8 (tbd)
 
 - Added new plugin `piral-tracker` for always-on components
+- Added optional `assetBaseUrl` property in `PiletInjector` configuration to specify base url of pilet asset
 
 ## 0.15.7 (February 10, 2023)
 

--- a/src/tooling/piral-cli/src/injectors/pilet-injector.ts
+++ b/src/tooling/piral-cli/src/injectors/pilet-injector.ts
@@ -23,6 +23,10 @@ export interface PiletInjectorConfig extends KrasInjectorConfig {
   app: string;
   feed?: string;
   headers: Record<string, string>;
+  /**
+   * Base url of pilet debug development server
+   */
+  assetBaseUrl?: string;
 }
 
 interface PiletMetadata {
@@ -83,14 +87,14 @@ export default class PiletInjector implements KrasInjector {
     this.serverConfig = serverConfig;
 
     if (this.config.active) {
-      const { pilets, api, publicUrl } = config;
+      const { pilets, api, publicUrl, assetBaseUrl } = config;
       this.indexPath = `${publicUrl}index.html`;
       const cbs = {};
 
       core.on('user-connected', (e) => {
         if (e.target === '*' && e.url === api.substring(1)) {
           cbs[e.id] = {
-            baseUrl: e.req.headers.origin,
+            baseUrl: assetBaseUrl || e.req.headers.origin,
             notify: (msg: string) => e.ws.send(msg),
           };
         }


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [✔️] I have read the **CONTRIBUTING** document
- [✔️] My code follows the code style of this project
- [✔️] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [✖️] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [✖️] I have updated the documentation accordingly
- [✖️] I have added tests to cover my changes

### Description
Optional config property `assetBaseUrl` added to `pilet-injector` config allows for user defined pilet asset location. This enables HMR and reload for developers who are debugging their appshell and pilets on a different host/domain than the pilet debug server is running.  

### Remarks

