### PR TITLE
Docs: Change the Route of the Code Search to "/codes/search" to Align With the Piral CLI Output

### DIFF
--- a/src/pages/docs/docs.config.json
+++ b/src/pages/docs/docs.config.json
@@ -19,7 +19,7 @@
     "./src/styles.scss"
   ],
   "pages": {
-    "/reference/codes/search": "./src/SearchPage.tsx"
+    "/code/search": "./src/SearchPage.tsx"
   },
   "redirects": {
     "/": "/guidelines",
@@ -29,6 +29,7 @@
     "/reference/tooling/piral": "/tooling/build-piral",
     "/reference/extensions/:id?": "/plugins/:id",
     "/reference/plugins/:id?": "/plugins/:id",
+    "/reference/codes/search": "/code/search",
     "/reference/codes/:id": "/code/:id"
   },
   "sitemap": {

--- a/src/pages/docs/docs.config.json
+++ b/src/pages/docs/docs.config.json
@@ -29,7 +29,6 @@
     "/reference/tooling/piral": "/tooling/build-piral",
     "/reference/extensions/:id?": "/plugins/:id",
     "/reference/plugins/:id?": "/plugins/:id",
-    "/reference/codes/search": "/code/search",
     "/reference/codes/:id": "/code/:id"
   },
   "sitemap": {


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

### Description

The Piral CLI, when running into an error code, tells us that we should go to https://docs.piral.io/code/search. The issue is that, at the moment, this page doesn't exist:
![grafik](https://github.com/smapiot/piral/assets/30902964/fd040f0f-55bd-4a2b-83e9-ce046c64961f)

I changed the routes/redirects in the documentation to match the output. I believe that the `/code/search` URL is the one we want to use (in contrast to the "old" `/reference/codes/search`)?

Locally, everything works fine now, see:
![grafik](https://github.com/smapiot/piral/assets/30902964/1c28e2da-2797-4a7d-ba41-05da9640223e)

![grafik](https://github.com/smapiot/piral/assets/30902964/0100f2eb-1e9f-4085-a716-7e9f77aaf816)


### Remarks

Does this go in the `documentation` branch? If not, change that please. 😄 
