### PR TITLE
fix: Fix codegen'd import statements in Windows environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 - Fixed build issue in codegen of `piral-core` on Windows (#619)
 - Updated `importmap` with `exclude` key allowing exclusions
 - Added support for `dependencySymbols` in `piral-blazor`
-- Fixed paths in codegen'd `import` statements when building in Windows environments
 
 ## 1.1.0 (July 25, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed issue with `loader-utils` version
 - Updated `importmap` with `exclude` key allowing exclusions
+- Fixed paths in codegen'd `import` statements when building in Windows environments
 
 ## 1.1.0 (July 25, 2023)
 

--- a/src/framework/piral-core/src/tools/codegen.ts
+++ b/src/framework/piral-core/src/tools/codegen.ts
@@ -1,7 +1,7 @@
 // this file is bundled, so the references here will not be at runtime (i.e., for a user)
 import { getModulePath } from 'piral-cli/src/external/resolve';
 import { readFileSync, existsSync } from 'fs';
-import { resolve, relative, dirname } from 'path';
+import { resolve, relative, dirname, sep, posix } from 'path';
 
 function findPackagePath(moduleDir: string) {
   const packageJson = 'package.json';
@@ -67,7 +67,11 @@ function getModulePathOrDefault(root: string, origin: string, name: string) {
   try {
     const absPath = getModulePath(root, name);
     const path = relative(origin, absPath);
-    return path;
+
+    // The relative path is to be used in an import statement,
+    // so it should be normalized back to use posix path separators.
+    const posixPath = path.split(sep).join(posix.sep);
+    return posixPath;
   } catch {
     return name;
   }


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

### Description

Fixes https://github.com/smapiot/piral/issues/619

For relative paths generated from the _piral-core_ codegen module, they are to be used in codegen'd import statements.  So the paths have to be normalized back to use posix-type slash path separators.

### Remarks

The issue only appears when a piral instance is being provisioned/built in a Windows environment.  Import statements should always be using the posix-style path separators.