### PR TITLE
Define Importmap Version Behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 - Fixed issue with global installation in pnpm (#624)
 - Fixed issue with `v.x` notation in semver comparisons
+- Fixed inclusion of directory entries in the pilet tarballs (#629)
 - Updated `piral-ng/common` to use Angular-version specific package `piral-ng-common`
 - Added support for features of v9 of Piral.Blazor in `piral-blazor` (#626)
 - Added `piral-content` custom element for rendering arbitrary children in foreign elements
+- Added configuration for default behavior of implicitly defined shared dependency version constraints (#625)
 
 ## 1.2.0 (August 28, 2023)
 

--- a/docs/static/schemas/pilet-v0.json
+++ b/docs/static/schemas/pilet-v0.json
@@ -11,6 +11,11 @@
       "enum": ["none", "v0", "v1", "v2", "v3"],
       "description": "The default output schema to be used when building the pilet."
     },
+    "importmapVersions": {
+      "type": "string",
+      "enum": ["all", "match-major", "any-patch", "exact"],
+      "description": "The default behavior for implicitly defined versions of shared dependencies."
+    },
     "piralInstances": {
       "type": "object",
       "description": "The app shells to be used for debugging the pilet. Each key defines the name of a Piral instance to be selectable.",

--- a/src/tooling/piral-cli/src/common/importmap.test.ts
+++ b/src/tooling/piral-cli/src/common/importmap.test.ts
@@ -1,0 +1,194 @@
+import { readImportmap } from './importmap';
+
+jest.mock('./npm', () => ({
+  tryResolvePackage(id, dir) {
+    return `${dir}/${id}/index.js`;
+  },
+}));
+
+const mockPackages = {
+  '/data/foo': {
+    name: 'foo',
+    version: '1.2.3',
+  },
+  '/data/bar': {
+    name: 'bar',
+    version: '1.0.0',
+  },
+};
+
+jest.mock('./io', () => ({
+  checkIsDirectory() {},
+  getHash() {},
+  readJson(dir) {
+    return mockPackages[dir];
+  },
+  findFile(dir, file) {
+    return `${dir}/${file}`;
+  },
+  checkExists() {
+    return true;
+  },
+}));
+
+describe('Importmap', () => {
+  it('reads empty one from package.json', async () => {
+    const deps = await readImportmap(
+      '/data',
+      {
+        importmap: {},
+      },
+      false,
+    );
+    expect(deps).toEqual([]);
+  });
+
+  it('reads fully qualified local dependency', async () => {
+    const deps = await readImportmap(
+      '/data',
+      {
+        importmap: {
+          imports: {
+            'foo@1.2.3': 'foo',
+          },
+        },
+      },
+      false,
+    );
+    expect(deps).toEqual([
+      {
+        alias: undefined,
+        entry: '/data/foo/index.js',
+        id: 'foo@1.2.3',
+        isAsync: false,
+        name: 'foo',
+        ref: 'foo.js',
+        requireId: 'foo@1.2.3',
+        type: 'local',
+      },
+    ]);
+  });
+
+  it('reads fully qualified local dependency with implied exact version', async () => {
+    const deps = await readImportmap(
+      '/data',
+      {
+        importmap: {
+          imports: {
+            foo: 'foo',
+          },
+        },
+      },
+      false,
+    );
+    expect(deps).toEqual([
+      {
+        alias: undefined,
+        entry: '/data/foo/index.js',
+        id: 'foo@1.2.3',
+        isAsync: false,
+        name: 'foo',
+        ref: 'foo.js',
+        requireId: 'foo@1.2.3',
+        type: 'local',
+      },
+    ]);
+  });
+
+  it('reads fully qualified local dependency with implied match major version', async () => {
+    const deps = await readImportmap(
+      '/data',
+      {
+        importmap: {
+          imports: {
+            foo: 'foo',
+          },
+        },
+      },
+      false,
+      'match-major',
+    );
+    expect(deps).toEqual([
+      {
+        alias: undefined,
+        entry: '/data/foo/index.js',
+        id: 'foo@1.2.3',
+        isAsync: false,
+        name: 'foo',
+        ref: 'foo.js',
+        requireId: 'foo@1.x',
+        type: 'local',
+      },
+    ]);
+  });
+
+  it('reads fully qualified local dependency with implied match major patch', async () => {
+    const deps = await readImportmap(
+      '/data',
+      {
+        importmap: {
+          imports: {
+            foo: 'foo',
+          },
+        },
+      },
+      false,
+      'any-patch',
+    );
+    expect(deps).toEqual([
+      {
+        alias: undefined,
+        entry: '/data/foo/index.js',
+        id: 'foo@1.2.3',
+        isAsync: false,
+        name: 'foo',
+        ref: 'foo.js',
+        requireId: 'foo@1.2.x',
+        type: 'local',
+      },
+    ]);
+  });
+
+  it('reads fully qualified local dependency with implied any match', async () => {
+    const deps = await readImportmap(
+      '/data',
+      {
+        importmap: {
+          imports: {
+            foo: 'foo',
+          },
+        },
+      },
+      false,
+      'all',
+    );
+    expect(deps).toEqual([
+      {
+        alias: undefined,
+        entry: '/data/foo/index.js',
+        id: 'foo@1.2.3',
+        isAsync: false,
+        name: 'foo',
+        ref: 'foo.js',
+        requireId: 'foo@*',
+        type: 'local',
+      },
+    ]);
+  });
+
+  it('fails when the local version does not match the desired version', async () => {
+    await expect(
+      readImportmap(
+        '/data',
+        {
+          importmap: {
+            imports: {
+              'bar@^2.0.0': '',
+            },
+          },
+        },
+        false,
+      ),
+    ).rejects.toThrow();
+  });
+});

--- a/src/tooling/piral-cli/src/common/package.ts
+++ b/src/tooling/piral-cli/src/common/package.ts
@@ -807,7 +807,7 @@ export async function retrievePiletData(target: string, app?: string) {
     });
   }
 
-  const importmap = await readImportmap(root, piletPackage);
+  const importmap = await readImportmap(root, piletPackage, undefined, piletDefinition?.importmapVersions);
 
   return {
     dependencies: piletPackage.dependencies || {},

--- a/src/tooling/piral-cli/src/types/internal.ts
+++ b/src/tooling/piral-cli/src/types/internal.ts
@@ -1,11 +1,12 @@
 import type { LogLevels } from './common';
-import type { PiletSchemaVersion } from './public';
+import type { ImportmapVersions, PiletSchemaVersion } from './public';
 
 /**
  * Shape of the pilet.json
  */
 export interface PiletDefinition {
   schemaVersion?: PiletSchemaVersion;
+  importmapVersions?: ImportmapVersions;
   piralInstances?: Record<
     string,
     {

--- a/src/tooling/piral-cli/src/types/public.ts
+++ b/src/tooling/piral-cli/src/types/public.ts
@@ -219,6 +219,8 @@ export interface BundlerDefinition {
   buildPilet: BuildPiletBundlerDefinition;
 }
 
+export type ImportmapVersions = 'all' | 'match-major' | 'any-patch' | 'exact';
+
 export type PiletSchemaVersion = 'none' | 'v0' | 'v1' | 'v2' | 'v3';
 
 export type SourceLanguage = 'js' | 'ts';


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes

### Description

Adds a special flag to the `pilet.json`, which can be used to define / override the default behavior when no version spec is given for a shared dependency.

### Remarks

The default behavior is an exact match, but very often this is not what is wanted. In the future we might actually have the `match-major` behavior set (by default) in the pilet.json. Therefore, existing pilets will keep to work as-is, while newly scaffolded ones come with a new default, which can be seen and changed directly.
