### PR TITLE
CLI: Handle Absence of `devDependencies` in `package.json` Files

### DIFF
--- a/src/tooling/piral-cli/src/common/importmap.ts
+++ b/src/tooling/piral-cli/src/common/importmap.ts
@@ -320,7 +320,7 @@ async function consumeImportmap(
 ): Promise<Array<SharedDependency>> {
   const importmap = packageDetails.importmap;
   const appShell = inherited && mode === 'remote';
-  const availableSpecs = appShell ? packageDetails.devDependencies : {};
+  const availableSpecs = appShell ? packageDetails.devDependencies ?? {} : {};
   const inheritanceBehavior = appShell ? 'host' : mode;
 
   if (typeof importmap === 'string') {


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

### Description

We were running into an issue where the `pilet build ...` command failed building the pimon-portal sample project on the newest Piral version (1.3.2) on Windows. The output was simply:

```
npm run start:fe:pilets

> start:fe:pilets
> pilet debug packages/frontend/*-pilet

+ piral-cli v1.3.2
⠋ Reading configuration ...
TypeError: Cannot read properties of undefined (reading '@emotion/react')
```

It seems that the error originated from the lack of a `devDependencies` section in the project's app shell package. Adding this section with an empty record `{}` makes the build work again.

I traced the error down by adding logs to the CLI's JS files and got this stack trace:
```
TypeError: Cannot read properties of undefined (reading '@emotion/react')
    at getDependencyDetails (C:\Development\smapiot\Piral\pimon-portal\node_modules\piral-cli\lib\common\importmap.js:56:39)
    at C:\Development\smapiot\Piral\pimon-portal\node_modules\piral-cli\lib\common\importmap.js:137:71
    at Generator.next (<anonymous>)
    at C:\Development\smapiot\Piral\pimon-portal\node_modules\piral-cli\lib\common\importmap.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (C:\Development\smapiot\Piral\pimon-portal\node_modules\piral-cli\lib\common\importmap.js:4:12)
    at resolveImportmap (C:\Development\smapiot\Piral\pimon-portal\node_modules\piral-cli\lib\common\importmap.js:119:12)
    at C:\Development\smapiot\Piral\pimon-portal\node_modules\piral-cli\lib\common\importmap.js:268:22
    at Generator.next (<anonymous>)
    at C:\Development\smapiot\Piral\pimon-portal\node_modules\piral-cli\lib\common\importmap.js:8:71 TypeError: Cannot read properties of undefined (reading '@emotion/react')
    at getDependencyDetails (C:\Development\smapiot\Piral\pimon-portal\node_modules\piral-cli\lib\common\importmap.js:56:39)
    at C:\Development\smapiot\Piral\pimon-portal\node_modules\piral-cli\lib\common\importmap.js:137:71
    at Generator.next (<anonymous>)
    at C:\Development\smapiot\Piral\pimon-portal\node_modules\piral-cli\lib\common\importmap.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (C:\Development\smapiot\Piral\pimon-portal\node_modules\piral-cli\lib\common\importmap.js:4:12)
    at resolveImportmap (C:\Development\smapiot\Piral\pimon-portal\node_modules\piral-cli\lib\common\importmap.js:119:12)
    at C:\Development\smapiot\Piral\pimon-portal\node_modules\piral-cli\lib\common\importmap.js:268:22
    at Generator.next (<anonymous>)
    at C:\Development\smapiot\Piral\pimon-portal\node_modules\piral-cli\lib\common\importmap.js:8:71
```

...which makes me think that adding the fallback in this PR could solve the issue. By using a `devDependencies` fallback of `{}`, `availableSpecs` is not `undefined` and should then not cause the error in `resolveImportmap > getDependencyDetails`.

### Remarks

None.