### PR TITLE
fix: Exclude target from pack

### DIFF
--- a/src/tooling/piral-cli/src/common/pack.ts
+++ b/src/tooling/piral-cli/src/common/pack.ts
@@ -85,6 +85,13 @@ export async function createPiletPackage(baseDir: string, source: string, target
   log('generalDebug_0003', `Reading out unique files from "${content}" ...`);
   const uniqueFiles = await getUniqueFiles(files);
 
+  // Edge case: If the files to be packaged contains the destination .tgz file, e.g., as a leftover
+  // from a previous build/pack, exclude that file, because it will be overwritten/replaced in the
+  // upcoming steps.
+  if (uniqueFiles.includes(file)) {
+    uniqueFiles.splice(uniqueFiles.indexOf(file), 1);
+  }
+
   log('generalDebug_0003', `Creating directory if not exist for "${file}" ...`);
   await createDirectory(dirname(file));
 


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

### Description

Removes the target `.tgz` file from the list of files to be packed in the `pilet pack` command. This should solve an issue where packing of pilets fails when the target exists in the `dist` directory, e.g., as a leftover from a previous build.

### Remarks
_None._