### PR TITLE
Docs: Rendering Breadcrumbs

### DIFF
--- a/src/plugins/piral-breadcrumbs/README.md
+++ b/src/plugins/piral-breadcrumbs/README.md
@@ -75,16 +75,11 @@ export function setup(piral: PiletApi) {
 
 ### Rendering Breadcrumbs
 
-Within pilets, you typically _cannot_ access the `Breadcrumbs` component from the `piral-breadcrumbs`. While there are several options to work around this, the simplest is to use a built-in extension provided by Piral called `piral-breadcrumbs`:
+While there are several options to render breadcrumbs in a pilet, Piral provides a built-in extension called `piral-breadcrumbs` which handles everything for you:
 
 ```tsx
 // Within any pilet:
-return (
-  <>
-    <Extension name="piral-breadcrumbs" />
-    {otherContent}
-  </>
-);
+<piral-extension name="piral-breadcrumbs"></piral-extension>
 ```
 
 :::

--- a/src/plugins/piral-breadcrumbs/README.md
+++ b/src/plugins/piral-breadcrumbs/README.md
@@ -73,6 +73,20 @@ export function setup(piral: PiletApi) {
 }
 ```
 
+### Rendering Breadcrumbs
+
+Within pilets, you typically _cannot_ access the `Breadcrumbs` component from the `piral-breadcrumbs`. While there are several options to work around this, the simplest is to use a built-in extension provided by Piral called `piral-breadcrumbs`:
+
+```tsx
+// Within any pilet:
+return (
+  <>
+    <Extension name="piral-breadcrumbs" />
+    {otherContent}
+  </>
+);
+```
+
 :::
 
 ::: summary: For Piral instance developers
@@ -117,6 +131,22 @@ const instance = createInstance({
   })],
   // ...
 });
+```
+
+### Rendering Breadcrumbs
+
+From within a Piral instance, you can render the current breadcrumbs via the `Breadcrumbs` component:
+
+```tsx
+import { Breadcrumbs } from 'piral-breadcrumbs';
+
+// Render it via:
+return (
+  <>
+    <Breadcrumbs />
+    {otherContent}
+  </>
+);
 ```
 
 ### Customizing


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

### Description

Documents how breadcrumbs can be rendered from an app shell and from pilets, respectively. I think this is not yet described anywhere. The only location where I found some details about how to render breadcrumbs, from pilets specifically, were in [this chat message](https://matrix.to/#/!ElKhNpTapGBHAKdcTm:gitter.im/$FStaTYvbB_YnC8w4tZq8HSExaFVxaLvTDQ-z67Cj4-o?via=gitter.im&via=matrix.org&via=matrix.freyachat.eu).

### Remarks

_None._