### PR TITLE
`piral-translate`: Do not replace falsy variables with an empty string

### DIFF
--- a/src/plugins/piral-translate/src/localize.test.ts
+++ b/src/plugins/piral-translate/src/localize.test.ts
@@ -8,6 +8,7 @@ const messages = {
   en: {
     hi: 'hello',
     greeting: 'Hi {{name}}, welcome back',
+    secretNumber: 'The secret number is {{number}}.',
     header: {
       title: 'Hello world'
     }
@@ -78,6 +79,12 @@ describe('Localize Module', () => {
     const localizer = new Localizer(messages, 'en');
     const result = localizer.localizeGlobal('greeting', { name: undefined });
     expect(result).toBe('Hi , welcome back');
+  });
+
+  it('localizeGlobal does not replace falsy variables with an empty string', () => {
+    const localizer = new Localizer(messages, 'en');
+    const result = localizer.localizeGlobal('secretNumber', { number: 0 });
+    expect(result).toBe('The secret number is 0.');
   });
 
   it('localizeGlobal translates from global translations using passed nested translations', () => {

--- a/src/plugins/piral-translate/src/localize.ts
+++ b/src/plugins/piral-translate/src/localize.ts
@@ -16,7 +16,7 @@ function defaultFallback(key: string, language: string): string {
 
 function formatMessage<T extends object>(message: string, variables: T): string {
   return message.replace(/{{\s*([A-Za-z0-9_.]+)\s*}}/g, (_match: string, p1: string) => {
-    return p1 in variables ? variables[p1] || '' : `{{${p1}}}`;
+    return p1 in variables ? variables[p1] ?? '' : `{{${p1}}}`;
   });
 }
 


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes

### Description

Updates `piral-translate` so that falsy variables are not replaced with an empty string. This is currently causing issues in an application where we have text like `"Number of items: {{number}}."`. If the variable `number` is `0`, the final translated text is `Number of items: .` instead of the expected `Number of items: 0.`.

### Remarks
I don't think that this should be breaking in a bad way for anyone, but am happy to be told otherwise..