### PR TITLE
Feature/#703 typed injectiontokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Piral Changelog
 
+## 1.6.1 (TBD)
+
+- Added `InjectionToken` constants `PIRAL`, `CONTEXT` and `PROPS` for compatibility with Angular's `inject` function to `piral-ng` (#703)  
+
 ## 1.6.0 (July 5, 2024)
 
 - Fixed event dispatching for providers in `piral-blazor`

--- a/src/converters/piral-ng/README.md
+++ b/src/converters/piral-ng/README.md
@@ -429,7 +429,14 @@ Depending on the mounted component different services are injected. the followin
 | Extension | `Props` | `piral` | `Context` |
 | Menu      | `Props` | `piral` | `Context` |
 
-To use such a service the `@Inject` decorator should be used with the explicit name.
+`piral-ng` also exports typed `InjectionToken` constants compatible with Angular's `inject` function:
+- `PROPS`
+- `PIRAL`
+- `CONTEXT`
+
+To use such a service you should:
+- either use the `@Inject` parameter decorator with the explicit name
+- or use the `inject` function with the imported token
 
 The following code snippet illustrates the injection of the `Props` service from an `TileProps` interface into a sample tile component.
 

--- a/src/converters/piral-ng/src/index.ts
+++ b/src/converters/piral-ng/src/index.ts
@@ -1,2 +1,3 @@
 export * from './create';
 export * from './types';
+export * from './injection';

--- a/src/converters/piral-ng/src/injection.ts
+++ b/src/converters/piral-ng/src/injection.ts
@@ -1,0 +1,6 @@
+import { InjectionToken } from '@angular/core';
+import { ComponentContext, PiletApi } from 'piral-core';
+
+export const PROPS = new InjectionToken<any>('Props');
+export const PIRAL = new InjectionToken<PiletApi>('piral');
+export const CONTEXT = new InjectionToken<ComponentContext>('Context');

--- a/src/converters/piral-ng/src/module.ts
+++ b/src/converters/piral-ng/src/module.ts
@@ -12,6 +12,7 @@ import {
   NgModule,
   NgZone,
 } from '@angular/core';
+import { PIRAL, PROPS } from './injection';
 import { teardown } from './startup';
 import { RoutingService } from './RoutingService';
 import { findComponents, getAnnotations } from './utils';
@@ -40,7 +41,9 @@ function instantiateModule(moduleDef: ModuleDefinition, piral: PiletApi) {
   const providers = [
     RoutingService,
     { provide: 'Props', useFactory: createProxy, deps: [] },
+    { provide: PROPS, useFactory: createProxy, deps: [] },
     { provide: 'piral', useFactory: () => piral, deps: [] },
+    { provide: PIRAL, useFactory: () => piral, deps: [] },
   ];
 
   @NgModule({

--- a/src/converters/piral-ng/src/standalone.ts
+++ b/src/converters/piral-ng/src/standalone.ts
@@ -9,6 +9,7 @@ import {
 } from '@angular/core';
 import type { BaseComponentProps, HtmlComponent } from 'piral-core';
 import { CoreRoutingService } from './CoreRoutingService';
+import { CONTEXT, PIRAL } from './injection';
 
 function isLazyLoader(thing: NgStandaloneComponent): thing is NgStandaloneComponentLoader {
   return typeof thing === 'function' && thing.hasOwnProperty('prototype') && thing.hasOwnProperty('arguments');
@@ -53,7 +54,9 @@ export function createConverter(options: ApplicationConfig): NgStandaloneConvert
               CoreRoutingService,
               { provide: APP_BASE_HREF, useValue: ctx.publicPath },
               { provide: 'Context', useValue: ctx },
+              { provide: CONTEXT, useValue: ctx },
               { provide: 'piral', useValue: piral },
+              { provide: PIRAL, useValue: piral },
             ],
           });
 


### PR DESCRIPTION
# New Pull Request

Closes #703 

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project (I hope so)
- [ ] All new and existing tests passed (see below)

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes (see below)

### Description

This adds new `InjectionToken` constants to `piral-ng` and additionally registers the known services using these tokens.
This improves compatibility with Angular's `inject` function.

### Remarks

I've written this PR without actually being a consumer of this project. So my understanding of it is limited.

**Existing tests:** on my system some tests have failed before the change, still failing after the change:
- src/tooling/piral-cli/src/common/npm.test.ts > npm Module > makeFilePath returns valid file path
- src/tooling/piral-cli/src/common/npm.test.ts > npm Module > gets path to file package
- src/tooling/piral-cli/src/common/utils.test.ts > only unique > should filter out child directories from back

**New tests:** Setting up an automated test for `piral-ng` is currently beyond my scope / understanding of this project.
A reasonable test (be it manual or automated) would ensure:
- Using the new tokens in `inject` survives the type check (in contrast to the existing string based tokens)
- Using the new tokens in `inject` or `@Inject` really leads to injection of the services

**Injection token types:** I'm also a bit unsure about the typing of the `PROPS` token. Currently it's `InjectionToken<any>`.
Without much experience in this project, it seems to me that almost anything can be passed here. Perhaps `any` can be improved to `Record<string, any>` or something similar but a simple `any` should make sure the consumer can just write down their own props type on the `@Inject`-decorated parameter / `inject`-assigned field.

**Injection token names:**: I've reproduced the original service names (uppercase) to name the exported injection token constants. The names passed to the `InjectionToken` constructor are just for debugging purposes.

Feel free to edit anything in this PR.