### PR TITLE
Added App Shell Sharing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.7.0 (tbd)
 
-- ...
+- Added support for `shared` key in *piral.json*
 
 ## 1.6.2 (September 27, 2024)
 

--- a/docs/static/schemas/piral-v0.json
+++ b/docs/static/schemas/piral-v0.json
@@ -83,6 +83,14 @@
       ],
       "description": "Defines what isolation / component wrapper is used for components of micro frontends. By default, the 'classic' isolation mode is used."
     },
+    "shared": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "description": "Path to the file to consider for sharing from the app shell."
+      },
+      "description": "Defines what files to share directly as exports from the app shell."
+    },
     "pilets": {
       "type": "object",
       "description": "Determines the scaffolding and upgrading behavior of pilets using this Piral instance.",

--- a/docs/tutorials/13-sharing-from-piral.md
+++ b/docs/tutorials/13-sharing-from-piral.md
@@ -157,6 +157,12 @@ The API can be much more dynamic and powerful (e.g., even coupling to the global
 
 This way is our recommendation for dynamic data and functions that require protection. Besides building convenience wrappers around the global state container it can also leverage pilet specific behavior.
 
+## Extending the App Shell Exports
+
+Our recommendation is to only use the Piral instance from your pilets as a type construct / for development purposes. At runtime no significant exports should be used within a pilet. However, if you really want your pilet to strongly depend on the app shell you can also use full exports using the `shared` key in the *piral.json*.
+
+For more information on this look at the [documentation for sharing dependencies](./15-share-dependencies.md).
+
 ## Conclusion
 
 Sharing information from the Piral instance can be done in multiple ways. Depending on the needs of the application and its pilets one way or another may be the best. Usually, an app shell uses all these ways to build an outstanding experience for both - users and developers.

--- a/docs/tutorials/15-share-dependencies.md
+++ b/docs/tutorials/15-share-dependencies.md
@@ -12,7 +12,9 @@ Sharing dependencies is one of the selling points of Piral. The key, however, is
 
 Our recommendation is to keep the sharing of dependencies from the app shell as practical as possible.
 
-## Declarative Sharing from the App Shell
+## Sharing from the App Shell
+
+### Declarative Sharing from the App Shell
 
 The easiest way to share dependencies from the app shell is to declare them in the `importmap` section of the *package.json*.
 
@@ -58,7 +60,7 @@ you get automatically `tslib` as a shared dependency. If you would also add `pir
 
 You can remove inherited importmaps and replace them by explicit `imports` declarations, too.
 
-## Imperative Sharing from the App Shell
+### Imperative Sharing from the App Shell
 
 Dependencies can also be "defined" or explicitly mentioned in the program code of the app shell. The mechanism for this works via the `shareDependencies` option of the `createInstance` function.
 
@@ -101,7 +103,7 @@ const instance = createInstance({
 
 By default, we do not recommend exporting functionality from the app shell. A Piral instance should **only deliver types** to the pilets. However, sometimes having a dedicated package for extra functionality would either complicate things or is just not feasible.
 
-## Type Declarations
+### Type Declarations
 
 While the explicit way is great for gaining flexibility it comes with one caveat: For this kind of sharing types are not automatically inferred and generated. As a result, we need to place additional typings for our offerings.
 
@@ -135,6 +137,18 @@ declare module 'my-app-shell' {
 **Important**: These are just type-declarations. We could, of course, declare a module like `foo-bar`, however, if that is indeed used in a pilet the build will potentially fail. As long as no module with the given name exists, the bundler will not be able to resolve it - no matter what TypeScript assumes.
 
 The rule of thumb for sharing the type declarations is: Everything exported top-level will be associated with the app shell, and everything exported from an explicitly declared module will be associated with that module.
+
+### Exported Modules
+
+To simplify the process illustrated in the previous two sections you can use a special key called `shared` in your *pilet.json*, e.g.:
+
+```json
+{
+  "shared": ["./src/externals.ts"]
+}
+```
+
+This will use the exports from the given modules (in the previous example *./src/externals.ts*) to be available in pilets. Moreover, the given modules will be added to the types, i.e., work as if they had been defined as `extraTypes`, too.
 
 ## Sharing from Pilets
 

--- a/src/framework/piral-core/app.codegen
+++ b/src/framework/piral-core/app.codegen
@@ -23,6 +23,7 @@ module.exports = function () {
     publicPath: process.env.PIRAL_PUBLIC_PATH || '/',
     debug: debug && (cfg.debugSettings || {}),
     emulator: !!process.env.DEBUG_PILET,
+    shared: Array.isArray(cfg.shared) ? cfg.shared : [],
     isolation: cfg.isolation || 'classic',
   };
 

--- a/src/framework/piral-core/src/tools/codegen.ts
+++ b/src/framework/piral-core/src/tools/codegen.ts
@@ -82,6 +82,7 @@ interface CodegenOptions {
   origin: string;
   cat: string;
   appName: string;
+  shared: Array<string>;
   externals: Array<string>;
   publicPath: string;
   isolation: 'classic' | 'modern';
@@ -97,12 +98,23 @@ interface CodegenOptions {
 }
 
 export function createDependencies(imports: Array<string>, exports: Array<string>, opts: CodegenOptions) {
-  const { root, appName, externals, origin } = opts;
+  const { root, appName, externals, shared, origin } = opts;
   const assignments: Array<string> = [];
   const asyncAssignments: Array<string> = [];
 
   if (appName) {
-    assignments.push(`deps['${appName}']={}`);
+    const parts = [];
+
+    for (const item of shared) {
+      if (typeof item === 'string') {
+        const path = getModulePathOrDefault(root, origin, item);
+        const ref = `_${imports.length}`;
+        parts.push(`...${ref}`);
+        imports.push(`import * as ${ref} from ${JSON.stringify(path)}`);
+      }
+    }
+
+    assignments.push(`deps['${appName}']={${parts.join(',')}}`);
   }
 
   for (const external of externals) {

--- a/src/tooling/piral-cli/package.json
+++ b/src/tooling/piral-cli/package.json
@@ -75,7 +75,7 @@
   },
   "dependencies": {
     "css-conflict-inspector": "^0.2.1",
-    "dets": "^0.16.0",
+    "dets": "^0.16.2",
     "kras": "^0.17.0",
     "rimraf": "^3.0.0",
     "typescript": "^5.0.0",

--- a/src/tooling/piral-cli/src/common/package.ts
+++ b/src/tooling/piral-cli/src/common/package.ts
@@ -614,6 +614,7 @@ export async function retrievePiletsInfo(entryFile: string) {
     name: packageInfo.name,
     version: packageInfo.version,
     emulator: piralJsonPkg.emulator,
+    shared: piralJsonPkg.shared,
     framework,
     dependencies,
     scripts: packageInfo.scripts,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5179,10 +5179,10 @@ detect-libc@^1.0.3:
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==
 
-dets@^0.16.0:
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/dets/-/dets-0.16.0.tgz#f0fbc7955e90ef602e3ee42b49f10fd27542ad70"
-  integrity sha512-sqnrRoOHnexPnXY596j89DHu1BEfCD7WBWYKsahdpT85ajWbuJzpWl9HGtwgHmG94dLszSvBp4DvFuRAuuh25Q==
+dets@^0.16.2:
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/dets/-/dets-0.16.2.tgz#7c5f0873d4c56d6ec7c6481337e27771560a5187"
+  integrity sha512-W6NJsHULCg2o2kWDacMRJuRomPOj4gd/artS3DAy+jXYDw95kS0YVvdh/mbLnOkHuAK5xbXHtxxdVhYfmAvL3g==
 
 diff-sequences@^29.6.3:
   version "29.6.3"


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

### Description

This PR contains a new feature that simplifies sharing from the app shell itself. Instead of having to configure (to be precise: this is still possible) the `shareDependencies` option in `createInstance` you'll only need to add the shared modules / entry points to the `shared` key in the *piral.json*. It will be automatically picked up and the Piral instance will have some functional exports now, too.

### Remarks

We still discourage this - it puts quite a large dependency on the app shell; making the pilets that use such exports only work on the given app shell.
