### PR TITLE
fix(piral-modals): Modals weren’t stacking correctly on top of each other.

### DIFF
--- a/src/plugins/piral-modals/src/actions.test.ts
+++ b/src/plugins/piral-modals/src/actions.test.ts
@@ -65,10 +65,10 @@ describe('Modals Actions Module', () => {
   it('openModal adds a new modal', () => {
     const state: any = create(() => ({
       foo: 5,
-      modals: [{ id: 'b' }],
+      modals: [{ id: 'a' }],
     }));
     const ctx = createActions(state, createListener({}));
-    openModal(ctx, { id: 'a' });
+    openModal(ctx, { id: 'b' });
     expect(state.getState()).toEqual({
       foo: 5,
       modals: [{ id: 'a' }, { id: 'b' }],

--- a/src/plugins/piral-modals/src/actions.ts
+++ b/src/plugins/piral-modals/src/actions.ts
@@ -1,10 +1,10 @@
-import { withKey, withoutKey, prependItem, excludeOn, GlobalStateContext } from 'piral-core';
+import { withKey, withoutKey, excludeOn, GlobalStateContext, appendItem } from 'piral-core';
 import { ModalRegistration, OpenModalDialog } from './types';
 
 export function openModal(ctx: GlobalStateContext, dialog: OpenModalDialog) {
   ctx.dispatch((state) => ({
     ...state,
-    modals: prependItem(state.modals, dialog),
+    modals: appendItem(state.modals, dialog),
   }));
 }
 


### PR DESCRIPTION
Fixed issue where the most recently opened modal was not appearing on top and was instead appearing behind older modals.

Before :

![ScreenRecording2025-08-11at6 41 12PM-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/d6110f2c-f3b8-460d-902f-03c82e6d94c5)
After :

![Screen Recording 2025-08-11 at 6 54 27 PM-2](https://github.com/user-attachments/assets/b74b9c64-262d-4131-aa4e-0c8b8de54251)

