### PR TITLE
fix: calling addTranslations multiple times caused previously added translations to be removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Updated dependencies
 - Fixed issue in `pilet declaration` re-emitting remote types
+- Fixed issue in `piral-translate` where calling `addTranslation` multiple times caused previously added local translations to be removed
 
 ## 1.10.3 (March 24, 2026)
 

--- a/src/plugins/piral-translate/src/create.test.ts
+++ b/src/plugins/piral-translate/src/create.test.ts
@@ -225,4 +225,33 @@ describe('Create Localize API', () => {
 
     expect(result).toEqual(config.messages.fr.bar);
   });
+
+  it.each([true, false])('addTranslations merges local translations when called multiple times', (overwrite): void => {
+    const config = {
+      language: 'fr',
+    };
+
+    const firstMessages = {
+      fr: {
+        foo: 'fóo',
+      },
+    };
+
+    const secondMessages = {
+      fr: {
+        bar: 'bár (neu)',
+      },
+    };
+
+    const api = (createLocaleApi(setupLocalizer(config))(context) as any)();
+
+    api.addTranslations([firstMessages]);
+    api.addTranslations([secondMessages], overwrite);
+
+    const resultFoo = api.translate('foo');
+    const resultBar = api.translate('bar');
+
+    expect(resultFoo).toEqual(firstMessages.fr.foo);
+    expect(resultBar).toEqual(secondMessages.fr.bar);
+  });
 });

--- a/src/plugins/piral-translate/src/create.ts
+++ b/src/plugins/piral-translate/src/create.ts
@@ -54,7 +54,13 @@ export function setupLocalizer(config: LocaleConfig = {}): Localizable {
   const computeLang = config.language;
   const usedLang = typeof computeLang === 'function' ? computeLang(languages, defaultLang, 'en') : computeLang;
   const language = usedLang || defaultLang;
-  return new Localizer(msgs, language, languages.length ? languages : [language], config.fallbackLanguage, config.fallback);
+  return new Localizer(
+    msgs,
+    language,
+    languages.length ? languages : [language],
+    config.fallbackLanguage,
+    config.fallback,
+  );
 }
 
 /**
@@ -89,7 +95,9 @@ export function createLocaleApi(localizer: Localizable = setupLocalizer()): Pira
         addTranslations(messages, isOverriding = true) {
           const current = localizer.messages;
           setTranslations(
-            deepmerge.all<AnyLocalizationMessages>(isOverriding ? [current, ...messages] : [...messages, current]),
+            deepmerge.all<AnyLocalizationMessages>(
+              isOverriding ? [current, localTranslations, ...messages] : [...messages, current, localTranslations],
+            ),
           );
         },
         getCurrentLanguage(cb?: (l: string) => void): any {


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes

### Description

There was an issue where calling `addTranslations`overwrote previously added local translations with the new value.

The issue was:
```ts
// in a pilet
app.addTranslations([ { en: { foo: 'bar' } }]);
app.addTranslations([ { en: { bar: 'baz' } }]);
app.translate('foo'); // returned "missing translation", but should be "bar"
```

This PR aims to fix this.

### Remarks

--