### PR TITLE
Fix/prevent duplicate dom portals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Updated dependencies
 - Fixed issue in `pilet declaration` re-emitting remote types
 - Fixed issue in `piral-translate` where calling `addTranslation` multiple times caused previously added local translations to be removed
+- Fixed DOM portal updates appending duplicate portals when matching by object identity fails
 - Added version specifier in emulator for centrally shared dependencies (#835)
 
 ## 1.10.3 (March 24, 2026)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 - Updated dependencies
 - Fixed issue in `pilet declaration` re-emitting remote types
 - Fixed issue in `piral-translate` where calling `addTranslation` multiple times caused previously added local translations to be removed
-- Fixed DOM portal updates appending duplicate portals when matching by object identity fails
 - Added version specifier in emulator for centrally shared dependencies (#835)
+- Fixed DOM portal updates appending duplicate portals when matching by object identity fails (#838)
 
 ## 1.10.3 (March 24, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
 # Piral Changelog
 
-## 1.11.0 (tbd)
+## 1.11.1 (tbd)
+
+- Fixed DOM portal updates appending duplicate portals when matching by object identity fails (#838)
+
+## 1.11.0 (June 07, 2026)
 
 - Updated dependencies
 - Fixed issue in `pilet declaration` re-emitting remote types
 - Fixed issue in `piral-translate` where calling `addTranslation` multiple times caused previously added local translations to be removed
 - Added version specifier in emulator for centrally shared dependencies (#835)
-- Fixed DOM portal updates appending duplicate portals when matching by object identity fails (#838)
 
 ## 1.10.3 (March 24, 2026)
 

--- a/src/framework/piral-core/src/actions/portal.test.ts
+++ b/src/framework/piral-core/src/actions/portal.test.ts
@@ -70,6 +70,48 @@ describe('Piral-Core portal actions', () => {
     expect(portals.test).not.toBeNull();
   });
 
+  it('updatePortal replaces a portal with the same container', () => {
+    const children = React.createElement('div');
+    const container = {};
+    const stored = {
+      key: 'stored',
+      children: { children },
+      type: 'div',
+      props: null,
+      containerInfo: container,
+    } as unknown as React.ReactPortal & { containerInfo: unknown };
+    const current = {
+      key: 'current',
+      children: { children },
+      type: 'div',
+      props: null,
+      containerInfo: container,
+    } as unknown as React.ReactPortal & { containerInfo: unknown };
+    const next = {
+      key: 'next',
+      children: { children },
+      type: 'div',
+      props: null,
+      containerInfo: container,
+    } as unknown as React.ReactPortal & { containerInfo: unknown };
+
+    const state = create(() => ({
+      portals: { test: [stored] },
+    }));
+
+    const ctx: any = {
+      state,
+      dispatch(update) {
+        state.setState(update(state.getState()));
+      },
+    };
+
+    updatePortal(ctx, 'test', current, next);
+    const { portals } = ctx.state.getState();
+    expect(portals.test).toHaveLength(1);
+    expect(portals.test[0]).toBe(next);
+  });
+
   it('showPortal adds a portal', () => {
     const children = React.createElement('div');
     const newPortal: React.ReactPortal = { key: 'test', children: { children }, type: 'div', props: null };

--- a/src/framework/piral-core/src/actions/portal.ts
+++ b/src/framework/piral-core/src/actions/portal.ts
@@ -2,6 +2,14 @@ import { ReactPortal } from 'react';
 import { withoutKey, withKey, includeItem, excludeItem, replaceOrAddItem } from '../utils';
 import { GlobalStateContext } from '../types';
 
+type PortalWithContainer = ReactPortal & {
+  containerInfo?: unknown;
+};
+
+function getPortalContainer(portal: ReactPortal) {
+  return (portal as PortalWithContainer).containerInfo;
+}
+
 export function destroyPortal(ctx: GlobalStateContext, id: string) {
   ctx.dispatch((state) => ({
     ...state,
@@ -16,13 +24,20 @@ export function hidePortal(ctx: GlobalStateContext, id: string, entry: ReactPort
   }));
 }
 
+function isSamePortal(current: ReactPortal, candidate: ReactPortal) {
+  const currentContainer = getPortalContainer(current);
+  const candidateContainer = getPortalContainer(candidate);
+
+  return candidate === current || (!!currentContainer && currentContainer === candidateContainer);
+}
+
 export function updatePortal(ctx: GlobalStateContext, id: string, current: ReactPortal, next: ReactPortal) {
   ctx.dispatch((state) => ({
     ...state,
     portals: withKey(
       state.portals,
       id,
-      replaceOrAddItem(state.portals[id], next, (m) => m === current),
+      replaceOrAddItem(state.portals[id], next, (m) => isSamePortal(current, m)),
     ),
   }));
 }


### PR DESCRIPTION
# New Pull Request

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes

### Description

Fixes DOM portal updates so existing portals can be replaced by their target container, not only by React portal object identity.

Previously, `updatePortal` only replaced an existing portal when the stored portal object matched the `current` portal by reference. In some integration scenarios, such as repeated HTML extension prop updates, the portal object reference may no longer match while the portal still targets the same DOM container. In that case, `replaceOrAddItem` appended a new portal instead of replacing the existing one, which could render duplicate extension content. This behavior was observed in one of our Piral-based Angular applications when repeated extension prop updates caused duplicate extension content to be rendered.

This change keeps the existing object identity match and adds a fallback match using the portal `containerInfo`.

A regression test was added to verify that a portal with the same container is replaced instead of appended.

### Remarks

Validated with:

```sh
yarn vitest run src/framework/piral-core/src/actions/portal.test.ts