### PR TITLE
Fix/prevent duplicate dom portals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.11.1 (tbd)
 
-- Fixed DOM portal updates appending duplicate portals when matching by object identity fails (#838)
+- Fixed portal state updates being skipped for new React portal instances (#840)
 
 ## 1.11.0 (June 07, 2026)
 

--- a/src/framework/piral-core/src/actions/portal.test.ts
+++ b/src/framework/piral-core/src/actions/portal.test.ts
@@ -70,48 +70,6 @@ describe('Piral-Core portal actions', () => {
     expect(portals.test).not.toBeNull();
   });
 
-  it('updatePortal replaces a portal with the same container', () => {
-    const children = React.createElement('div');
-    const container = {};
-    const stored = {
-      key: 'stored',
-      children: { children },
-      type: 'div',
-      props: null,
-      containerInfo: container,
-    } as unknown as React.ReactPortal & { containerInfo: unknown };
-    const current = {
-      key: 'current',
-      children: { children },
-      type: 'div',
-      props: null,
-      containerInfo: container,
-    } as unknown as React.ReactPortal & { containerInfo: unknown };
-    const next = {
-      key: 'next',
-      children: { children },
-      type: 'div',
-      props: null,
-      containerInfo: container,
-    } as unknown as React.ReactPortal & { containerInfo: unknown };
-
-    const state = create(() => ({
-      portals: { test: [stored] },
-    }));
-
-    const ctx: any = {
-      state,
-      dispatch(update) {
-        state.setState(update(state.getState()));
-      },
-    };
-
-    updatePortal(ctx, 'test', current, next);
-    const { portals } = ctx.state.getState();
-    expect(portals.test).toHaveLength(1);
-    expect(portals.test[0]).toBe(next);
-  });
-
   it('showPortal adds a portal', () => {
     const children = React.createElement('div');
     const newPortal: React.ReactPortal = { key: 'test', children: { children }, type: 'div', props: null };

--- a/src/framework/piral-core/src/actions/portal.ts
+++ b/src/framework/piral-core/src/actions/portal.ts
@@ -2,14 +2,6 @@ import { ReactPortal } from 'react';
 import { withoutKey, withKey, includeItem, excludeItem, replaceOrAddItem } from '../utils';
 import { GlobalStateContext } from '../types';
 
-type PortalWithContainer = ReactPortal & {
-  containerInfo?: unknown;
-};
-
-function getPortalContainer(portal: ReactPortal) {
-  return (portal as PortalWithContainer).containerInfo;
-}
-
 export function destroyPortal(ctx: GlobalStateContext, id: string) {
   ctx.dispatch((state) => ({
     ...state,
@@ -24,20 +16,13 @@ export function hidePortal(ctx: GlobalStateContext, id: string, entry: ReactPort
   }));
 }
 
-function isSamePortal(current: ReactPortal, candidate: ReactPortal) {
-  const currentContainer = getPortalContainer(current);
-  const candidateContainer = getPortalContainer(candidate);
-
-  return candidate === current || (!!currentContainer && currentContainer === candidateContainer);
-}
-
 export function updatePortal(ctx: GlobalStateContext, id: string, current: ReactPortal, next: ReactPortal) {
   ctx.dispatch((state) => ({
     ...state,
     portals: withKey(
       state.portals,
       id,
-      replaceOrAddItem(state.portals[id], next, (m) => isSamePortal(current, m)),
+      replaceOrAddItem(state.portals[id], next, (m) => m === current),
     ),
   }));
 }

--- a/src/framework/piral-core/src/actions/state.test.ts
+++ b/src/framework/piral-core/src/actions/state.test.ts
@@ -37,4 +37,33 @@ describe('Piral-Core state actions', () => {
     }));
     expect(context.read().test).toBe(11);
   });
+
+  it('dispatch updates the portal state for new portal instances', () => {
+    const oldPortal = {
+      key: null,
+      children: 'content',
+      containerInfo: {},
+      implementation: null,
+    };
+    const newPortal = {
+      key: null,
+      children: 'content',
+      containerInfo: {},
+      implementation: null,
+    };
+    const { context } = createMockContainer({
+      portals: {
+        root: [oldPortal],
+      },
+    });
+
+    dispatch(context, (state: any) => ({
+      ...state,
+      portals: {
+        root: [newPortal],
+      },
+    }));
+
+    expect(context.read().portals.root[0]).toBe(newPortal);
+  });
 });

--- a/src/framework/piral-core/src/actions/state.ts
+++ b/src/framework/piral-core/src/actions/state.ts
@@ -5,7 +5,7 @@ export function dispatch(ctx: GlobalStateContext, update: (state: GlobalState) =
   const oldState = ctx.state.getState();
   const newState = update(oldState);
 
-  if (!isSame(oldState, newState)) {
+  if (oldState.portals !== newState.portals || !isSame(oldState, newState)) {
     ctx.state.setState(newState);
   }
 }


### PR DESCRIPTION
# New Pull Request

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes

### Description

This fixes an issue where portal state updates could be skipped when a new `ReactPortal` instance was created but considered structurally equal to the previous portal state.

In this case, `dispatch` did not call `setState`, so the global `state.portals` entry stayed on the old portal reference. Later portal updates could then fail to match the locally tracked current portal by reference, causing duplicate DOM portals to be appended.

The fix treats `state.portals` changes by reference while keeping the existing structural comparison for the rest of the global state.

In addition, I reverted the changes previously made in https://github.com/smapiot/piral/pull/838.

### Remarks

This behavior was observed in one of our Piral-based Angular applications when repeated extension prop updates caused duplicate portal content.