### PR TITLE
fix: ng-standalone mounting & update race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Piral Changelog
 
-## 1.11.1 (tbd)
+## 1.11.2 (tbd)
+
+- Fixed a race condition in `piral-ng`, where Props updates could get lost before mounting a component
+
+## 1.11.1 (June 16, 2026)
 
 - Fixed portal state updates being skipped for new React portal instances (#840)
 - Fixed reference to `main.css` in case there is no stylesheet in pilets (#839)

--- a/src/converters/piral-ng/src/standalone.ts
+++ b/src/converters/piral-ng/src/standalone.ts
@@ -42,8 +42,11 @@ export function createConverter(options: ApplicationConfig): NgStandaloneConvert
 
       if (ct?.ɵcmp?.inputs?.Props) {
         ref.setInput('Props', props);
+        return true;
       }
     }
+
+    return false;
   };
 
   let app: undefined | Promise<ApplicationRef> = undefined;
@@ -94,13 +97,22 @@ export function createConverter(options: ApplicationConfig): NgStandaloneConvert
               // Start the routing service.
               appRef.injector.get(CoreRoutingService);
 
-              update(ref, props);
+              const initialProps = 'initialProps' in locals ? locals.initialProps : props; // See `update` below.
+              update(ref, initialProps);
+
               locals.component = ref;
             }
           });
       },
       update(_1, props, _2, locals) {
-        update(locals.component, props);
+        // In some situations, update can be called before mount finishes (due to the async mounting behavior).
+        // In such cases, these early update calls, which should overwrite the initial props passed to mount,
+        // would get lost because setting the component input isn't possible yet.
+        // To circumvent this, early/failed update props are stored in locals. mount can then access these
+        // in place of the initial (old) props.
+        if (!update(locals.component, props)) {
+          locals.initialProps = props;
+        }
       },
       unmount(element, locals) {
         locals.active = false;


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

### Description

Fixes a race condition happening between `mount` and `update` in ng-standalone components.
Before this fix, the following flow could happen:

1. `mount` is called & starts its async process (with lazy-loading, for example)
2. `update` is immediately called. The component isn't mounted yet. `setInput` **fails**.
3. `mount` finishes and sets the initially received `props` as initial component input.

Issue: Component is mounted, but with old props. The newer version received via `update` got lost.

### Remarks

_None._