### PR TITLE
fix(piral-page-layouts): remove react-router coupling, make plugin router-agnostic (closes #770)

### DIFF
--- a/src/plugins/piral-page-layouts/src/actions.test.ts
+++ b/src/plugins/piral-page-layouts/src/actions.test.ts
@@ -1,0 +1,141 @@
+/**
+ * @vitest-environment jsdom
+ */
+import create from 'zustand';
+import { describe, it, expect, vitest } from 'vitest';
+import { registerPageLayout, unregisterPageLayout } from './actions';
+
+function createListener() {
+  return {
+    on: vitest.fn(),
+    off: vitest.fn(),
+    emit: vitest.fn(),
+  };
+}
+
+function createContext(state: any, listener: any) {
+  return {
+    ...listener,
+    state: state.getState(),
+    dispatch(change: any) {
+      state.setState(change(state.getState()));
+    },
+  };
+}
+
+describe('Page Layouts Actions Module', () => {
+  it('registerPageLayout adds to state registry', () => {
+    const state: any = create(() => ({
+      foo: 5,
+      registry: {
+        foo: 5,
+        pageLayouts: {},
+      },
+    }));
+    const ctx = createContext(state, createListener());
+    registerPageLayout(ctx, 'admin', { pilet: 'test-pilet', component: 'LayoutComp' as any });
+    expect(state.getState().registry.pageLayouts).toEqual({
+      admin: { pilet: 'test-pilet', component: 'LayoutComp' },
+    });
+  });
+
+  it('registerPageLayout preserves existing state fields', () => {
+    const state: any = create(() => ({
+      app: { name: 'test' },
+      components: { RouteSwitch: 'rs' },
+      registry: {
+        pageLayouts: {},
+        pages: { existing: 'page' },
+      },
+    }));
+    const ctx = createContext(state, createListener());
+    registerPageLayout(ctx, 'custom', { pilet: 'p1', component: 'c1' as any });
+    const result = state.getState();
+    expect(result.app).toEqual({ name: 'test' });
+    expect(result.components).toEqual({ RouteSwitch: 'rs' });
+    expect(result.registry.pages).toEqual({ existing: 'page' });
+    expect(result.registry.pageLayouts).toEqual({ custom: { pilet: 'p1', component: 'c1' } });
+  });
+
+  it('unregisterPageLayout removes from state registry', () => {
+    const state: any = create(() => ({
+      registry: {
+        pageLayouts: {
+          guest: { pilet: 'p1', component: 'g' },
+          admin: { pilet: 'p2', component: 'a' },
+        },
+      },
+    }));
+    const ctx = createContext(state, createListener());
+    unregisterPageLayout(ctx, 'guest');
+    expect(state.getState().registry.pageLayouts).toEqual({
+      admin: { pilet: 'p2', component: 'a' },
+    });
+  });
+
+  it('unregisterPageLayout is a no-op for non-existent key', () => {
+    const state: any = create(() => ({
+      registry: {
+        pageLayouts: {
+          admin: { pilet: 'p1', component: 'a' },
+        },
+      },
+    }));
+    const ctx = createContext(state, createListener());
+    unregisterPageLayout(ctx, 'nonexistent');
+    expect(state.getState().registry.pageLayouts).toEqual({
+      admin: { pilet: 'p1', component: 'a' },
+    });
+  });
+
+  it('registerPageLayout overwrites existing layout with same name', () => {
+    const state: any = create(() => ({
+      registry: {
+        pageLayouts: {
+          test: { pilet: 'old-pilet', component: 'old-comp' },
+        },
+      },
+    }));
+    const ctx = createContext(state, createListener());
+    registerPageLayout(ctx, 'test', { pilet: 'new-pilet', component: 'new-comp' as any });
+    expect(state.getState().registry.pageLayouts).toEqual({
+      test: { pilet: 'new-pilet', component: 'new-comp' },
+    });
+  });
+
+  it('registerPageLayout does not mutate the state directly', () => {
+    const state: any = create(() => ({
+      registry: { pageLayouts: {} },
+    }));
+    const ctx = createContext(state, createListener());
+    const originalState = state.getState();
+    registerPageLayout(ctx, 'a', { pilet: 'p', component: 'c' as any });
+    expect(originalState.registry.pageLayouts).toEqual({});
+  });
+
+  it('register and unregister round-trip restores original state', () => {
+    const state: any = create(() => ({
+      registry: {
+        pageLayouts: {},
+      },
+    }));
+    const ctx = createContext(state, createListener());
+    registerPageLayout(ctx, 'temp', { pilet: 'p', component: 'c' as any });
+    expect(Object.keys(state.getState().registry.pageLayouts)).toEqual(['temp']);
+    unregisterPageLayout(ctx, 'temp');
+    expect(state.getState().registry.pageLayouts).toEqual({});
+  });
+
+  it('handles empty string as layout name', () => {
+    const state: any = create(() => ({
+      registry: { pageLayouts: {} },
+    }));
+    const ctx = createContext(state, createListener());
+    registerPageLayout(ctx, '', { pilet: 'p', component: 'c' as any });
+    expect(state.getState().registry.pageLayouts).toEqual({
+      '': { pilet: 'p', component: 'c' },
+    });
+    unregisterPageLayout(ctx, '');
+    expect(state.getState().registry.pageLayouts).toEqual({});
+  });
+});

--- a/src/plugins/piral-page-layouts/src/create.test.ts
+++ b/src/plugins/piral-page-layouts/src/create.test.ts
@@ -1,0 +1,197 @@
+/**
+ * @vitest-environment jsdom
+ */
+import create from 'zustand';
+import { describe, it, expect, vitest } from 'vitest';
+import { createElement, FC } from 'react';
+import { createPageLayoutsApi } from './create';
+import type { PageLayoutRegistration } from './types';
+
+const StubComponent: FC = (props) => createElement('div', props);
+StubComponent.displayName = 'StubComponent';
+
+vitest.mock('piral-core', () => ({
+  useGlobalState: (select: any) => select,
+  useGlobalStateContext: () => ({}),
+  defaultRender: (c: any) => c,
+  defineActions: () => {},
+  withApi: (_ctx: any, component: any) => component,
+  withAll: (...args: any[]) => (state: any) => {
+    for (const fn of args) {
+      state = fn(state);
+    }
+    return state;
+  },
+  GlobalState: {} as any,
+  PiralPlugin: {} as any,
+  PageComponentProps: {} as any,
+  RouteSwitchProps: {} as any,
+  AppPath: {} as any,
+  Dict: {} as any,
+  ComponentType: {} as any,
+  buildName: (pilet: string, name: string | number) => `${pilet}-${name}`,
+  createRouteMatcher: (path: string) => new RegExp(path),
+  withRootExtension: () => () => ({}),
+}));
+
+function createMockContainer() {
+  const state = create(() => ({
+    app: { wrap: false },
+    registry: {
+      pageLayouts: {} as Record<string, PageLayoutRegistration>,
+      wrappers: {},
+    },
+    components: {
+      RouteSwitch: vitest.fn(),
+    },
+  }));
+  const dispatch = vitest.fn((update: any) => state.setState(update(state.getState())));
+  return {
+    context: {
+      on: vitest.fn(),
+      off: vitest.fn(),
+      emit: vitest.fn(),
+      defineActions: vitest.fn(),
+      readState: vitest.fn((select) => select(state.getState())),
+      state,
+      dispatch,
+      registerPageLayout: vitest.fn(),
+      unregisterPageLayout: vitest.fn(),
+    } as any,
+    api: { meta: { name: 'my-module' } } as any,
+  };
+}
+
+function createApi(container: any, config: any = {}) {
+  const plugin = createPageLayoutsApi(config);
+  const extender = plugin(container.context) as any;
+  if (typeof extender === 'function') {
+    Object.assign(container.api, extender(container.api, moduleMetadata));
+  } else {
+    Object.assign(container.api, extender);
+  }
+  return container.api;
+}
+
+const moduleMetadata = {
+  name: 'my-module',
+  version: '1.0.0',
+  link: undefined,
+  custom: undefined,
+  hash: '123',
+};
+
+describe('Create Page Layouts API Extensions', () => {
+  it('calls defineActions on setup', () => {
+    const container = createMockContainer();
+    createApi(container);
+    expect(container.context.defineActions).toHaveBeenCalled();
+  });
+
+  it('dispatches initial state with configured layouts', () => {
+    const container = createMockContainer();
+    createApi(container, {
+      fallback: 'custom-fallback',
+      layouts: { default: StubComponent },
+    });
+    expect(container.context.dispatch).toHaveBeenCalled();
+  });
+
+  it('registerPageLayout registers a new layout and returns a disposer that cleans up, readState permitting', () => {
+    const container = createMockContainer();
+    // readState returns undefined → !current → allows registration
+    container.context.readState = vitest.fn(() => undefined);
+    const api = createApi(container);
+
+    const dispose = api.registerPageLayout('my-layout', StubComponent);
+
+    expect(container.context.registerPageLayout).toHaveBeenCalledTimes(1);
+    expect(container.context.registerPageLayout.mock.calls[0][0]).toBe('my-layout');
+
+    // When readState returns undefined, unregisterPageLayout guard (current?.pilet === pilet)
+    // rejects since undefined?.pilet → undefined !== 'my-module'. This is the correct guard
+    // preventing pilet A from unregistering a layout that was never registered in state.
+    //
+    // With readState returning the actual layout after registration, dispose would succeed.
+    // That behavior is tested in "unregisterPageLayout removes a layout owned by the calling pilet".
+    expect(container.context.unregisterPageLayout).toHaveBeenCalledTimes(0);
+  });
+
+  it('unregisterPageLayout removes a layout owned by the calling pilet', () => {
+    const container = createMockContainer();
+    // Existing layout owned by this pilet
+    container.context.readState = vitest.fn(() => ({
+      pilet: 'my-module',
+      component: StubComponent,
+    }));
+    const api = createApi(container);
+
+    api.unregisterPageLayout('my-layout');
+    expect(container.context.unregisterPageLayout).toHaveBeenCalledTimes(1);
+  });
+
+  it('registerPageLayout blocks override when layout belongs to another pilet', () => {
+    const container = createMockContainer();
+    container.context.readState = vitest.fn(() => ({
+      pilet: 'other-pilet',
+      component: StubComponent,
+    }));
+    const api = createApi(container);
+
+    api.registerPageLayout('shared-layout', StubComponent);
+    expect(container.context.registerPageLayout).not.toHaveBeenCalled();
+  });
+
+  it('registerPageLayout allows re-register when layout belongs to same pilet', () => {
+    const container = createMockContainer();
+    container.context.readState = vitest.fn(() => ({
+      pilet: 'my-module',
+      component: StubComponent,
+    }));
+    const api = createApi(container);
+
+    api.registerPageLayout('my-layout', StubComponent);
+    expect(container.context.registerPageLayout).toHaveBeenCalledTimes(1);
+  });
+
+  it('unregisterPageLayout blocks removal when layout belongs to another pilet', () => {
+    const container = createMockContainer();
+    container.context.readState = vitest.fn(() => ({
+      pilet: 'other-pilet',
+      component: StubComponent,
+    }));
+    const api = createApi(container);
+
+    api.unregisterPageLayout('shared-layout');
+    expect(container.context.unregisterPageLayout).not.toHaveBeenCalled();
+  });
+
+  it('registerPageLayout registers when no layout exists (undefined readState)', () => {
+    const container = createMockContainer();
+    container.context.readState = vitest.fn(() => undefined);
+    const api = createApi(container);
+
+    api.registerPageLayout('fresh-layout', StubComponent);
+    expect(container.context.registerPageLayout).toHaveBeenCalledTimes(1);
+  });
+
+  it('multiple registerPageLayout calls each register with correct name', () => {
+    const container = createMockContainer();
+    container.context.readState = vitest.fn(() => undefined);
+    const api = createApi(container);
+
+    api.registerPageLayout('layout-a', StubComponent);
+    api.registerPageLayout('layout-b', StubComponent);
+
+    expect(container.context.registerPageLayout).toHaveBeenCalledTimes(2);
+    expect(container.context.registerPageLayout.mock.calls[0][0]).toBe('layout-a');
+    expect(container.context.registerPageLayout.mock.calls[1][0]).toBe('layout-b');
+  });
+
+  it('creates API functions even with empty config', () => {
+    const container = createMockContainer();
+    const api = createApi(container);
+    expect(api.registerPageLayout).toBeInstanceOf(Function);
+    expect(api.unregisterPageLayout).toBeInstanceOf(Function);
+  });
+});

--- a/src/plugins/piral-page-layouts/src/utils.test.tsx
+++ b/src/plugins/piral-page-layouts/src/utils.test.tsx
@@ -1,0 +1,222 @@
+/**
+ * @vitest-environment jsdom
+ */
+import * as React from 'react';
+import { createElement, FC } from 'react';
+import { describe, it, expect, vitest, beforeEach, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { getPageLayouts, withPageLayouts } from './utils';
+
+// --- Mocks ------------------------------------------------------------------
+
+let mockNavigationPath = '/';
+const mockNavigationListeners: Array<() => void> = [];
+
+vitest.mock('piral-core', async () => {
+  const actual = await vitest.importActual('piral-core') as any;
+  return {
+    ...actual,
+    useGlobalState: (select: any) => select(mockGlobalState),
+    useGlobalStateContext: () => ({
+      navigation: {
+        path: mockNavigationPath,
+        listen: (cb: () => void) => {
+          mockNavigationListeners.push(cb);
+          return () => {
+            const idx = mockNavigationListeners.indexOf(cb);
+            if (idx !== -1) mockNavigationListeners.splice(idx, 1);
+          };
+        },
+      },
+    }),
+    defaultRender: (child: any, key?: string) =>
+      createElement('span', { 'data-testid': 'default-render', key }, child),
+    GlobalState: {} as any,
+  };
+});
+
+// --- State ------------------------------------------------------------------
+
+let mockGlobalState: any;
+
+const DefaultLayout: FC = (props) => createElement('div', { 'data-testid': 'default-layout' }, props.children);
+const AdminLayout: FC = (props) => createElement('div', { 'data-testid': 'admin-layout' }, props.children);
+const GuestLayout: FC = (props) => createElement('div', { 'data-testid': 'guest-layout' }, props.children);
+
+const StubRoutes: FC = () => createElement('div', { 'data-testid': 'routes' }, 'Routes');
+const NotFound: FC = () => createElement('div', { 'data-testid': 'not-found' }, 'Not Found');
+
+// ---------------------------------------------------------------------------
+
+describe('getPageLayouts', () => {
+  it('converts component record to PageLayoutRegistration dict', () => {
+    const result = getPageLayouts({ default: DefaultLayout, admin: AdminLayout });
+    expect(result).toEqual({
+      default: { pilet: undefined, component: DefaultLayout },
+      admin: { pilet: undefined, component: AdminLayout },
+    });
+  });
+
+  it('returns empty object for null input', () => {
+    expect(getPageLayouts(null as any)).toEqual({});
+  });
+
+  it('returns empty object for undefined input', () => {
+    expect(getPageLayouts(undefined as any)).toEqual({});
+  });
+
+  it('returns empty object for non-object input', () => {
+    expect(getPageLayouts('string' as any)).toEqual({});
+    expect(getPageLayouts(42 as any)).toEqual({});
+    expect(getPageLayouts(true as any)).toEqual({});
+  });
+
+  it('returns empty object for empty object', () => {
+    expect(getPageLayouts({})).toEqual({});
+  });
+
+  it('preserves component identity', () => {
+    const result = getPageLayouts({ foo: DefaultLayout });
+    expect(result.foo.component).toBe(DefaultLayout);
+  });
+});
+
+describe('withPageLayouts', () => {
+  beforeEach(() => {
+    mockGlobalState = {
+      components: { RouteSwitch: StubRoutes },
+      registry: { pageLayouts: {} },
+    };
+  });
+
+  it('wraps RouteSwitch with the given fallback', () => {
+    const layouts = getPageLayouts({ admin: AdminLayout });
+    const updater = withPageLayouts(layouts, 'admin');
+    const newState = updater(mockGlobalState);
+    expect(newState.components.RouteSwitch).not.toBe(StubRoutes);
+    expect(newState.registry.pageLayouts).toEqual(layouts);
+  });
+
+  it('does not mutate the original state', () => {
+    const layouts = getPageLayouts({ guest: GuestLayout });
+    const updater = withPageLayouts(layouts, 'guest');
+    const originalComponents = mockGlobalState.components;
+    const originalRegistry = mockGlobalState.registry;
+    updater(mockGlobalState);
+    expect(mockGlobalState.components).toBe(originalComponents);
+    expect(mockGlobalState.registry).toBe(originalRegistry);
+  });
+
+  it('preserves other state fields', () => {
+    const layouts = getPageLayouts({});
+    const updater = withPageLayouts(layouts, 'default');
+    const stateWithExtra = { ...mockGlobalState, foo: 'bar' as any };
+    const result = updater(stateWithExtra);
+    expect((result as any).foo).toBe('bar');
+  });
+
+  it('injects pageLayouts into registry', () => {
+    const layouts = getPageLayouts({ admin: AdminLayout, guest: GuestLayout });
+    const updater = withPageLayouts(layouts, 'guest');
+    const newState = updater(mockGlobalState);
+    expect(newState.registry.pageLayouts).toBe(layouts);
+  });
+});
+
+describe('createPageWrapper (rendering)', () => {
+  beforeEach(() => {
+    mockNavigationPath = '/';
+    mockNavigationListeners.length = 0;
+    mockGlobalState = {
+      components: {
+        RouteSwitch: StubRoutes,
+      },
+      registry: {
+        pageLayouts: {
+          default: { pilet: undefined, component: DefaultLayout },
+          admin: { pilet: undefined, component: AdminLayout },
+        },
+      },
+    };
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  function makePath(path: string, matcher: RegExp, meta: any = {}) {
+    return { path, matcher, meta, Component: null };
+  }
+
+  function mountWrapper(fallback = 'default') {
+    const layouts = getPageLayouts(mockGlobalState.registry.pageLayouts);
+    const updater = withPageLayouts(layouts as any, fallback);
+    const newState = updater(mockGlobalState);
+    const WrappedSwitch = newState.components.RouteSwitch;
+    const paths = [
+      makePath('/', /^\/$/, { layout: 'default' }),
+      makePath('/admin', /^\/admin(\/|$)/, { layout: 'admin' }),
+      makePath('/guest', /^\/guest(\/|$)/, {}),
+    ];
+    return render(createElement(WrappedSwitch as any, { paths, NotFound, navigation: {} }));
+  }
+
+  // --- Initial render tests (before any navigation) ---
+
+  it('renders layout matching initial navigation.path', () => {
+    mockNavigationPath = '/';
+    const { getByTestId } = mountWrapper();
+    expect(getByTestId('default-layout')).toBeTruthy();
+  });
+
+  it('renders admin layout when path starts on /admin', () => {
+    mockNavigationPath = '/admin';
+    const { getByTestId } = mountWrapper();
+    expect(getByTestId('admin-layout')).toBeTruthy();
+  });
+
+  it('falls back to default when no layout meta exists on the matched route', () => {
+    mockNavigationPath = '/guest';
+    const { getByTestId } = mountWrapper();
+    expect(getByTestId('default-layout')).toBeTruthy();
+  });
+
+  it('falls back to defaultRender when no layout registered at all', () => {
+    mockGlobalState.registry.pageLayouts = {};
+    mockNavigationPath = '/nowhere';
+    const { getByTestId } = mountWrapper();
+    expect(getByTestId('default-render')).toBeTruthy();
+    expect(getByTestId('routes')).toBeTruthy();
+  });
+
+  // --- Router-agnostic path detection ---
+
+  it('reads navigation.path directly (not { location } from callback) for initial path', () => {
+    mockNavigationPath = '/some-custom';
+    const { getByTestId } = mountWrapper();
+    // Falls to default since /some-custom doesn't match admin
+    expect(getByTestId('default-layout')).toBeTruthy();
+  });
+
+  // --- Listener lifecycle ---
+
+  it('registers navigation listener on mount', () => {
+    const { unmount } = mountWrapper();
+    expect(mockNavigationListeners.length).toBeGreaterThanOrEqual(1);
+    unmount();
+  });
+
+  it('unregisters navigation listener on unmount', () => {
+    const { unmount } = mountWrapper();
+    const countBefore = mockNavigationListeners.length;
+    unmount();
+    expect(mockNavigationListeners.length).toBe(countBefore - 1);
+  });
+
+  it('wraps children (Routes) inside the layout component', () => {
+    mockNavigationPath = '/admin';
+    const { getByTestId } = mountWrapper();
+    const admin = getByTestId('admin-layout');
+    expect(admin.contains(getByTestId('routes'))).toBe(true);
+  });
+});

--- a/src/plugins/piral-page-layouts/src/utils.ts
+++ b/src/plugins/piral-page-layouts/src/utils.ts
@@ -28,8 +28,8 @@ function createPageWrapper(
     const [layout, setLayout] = useState(() => findLayout(props.paths, navigation.path, fallback));
 
     useEffect(() => {
-      return navigation.listen(({ location }) => {
-        setLayout(findLayout(props.paths, location.pathname, fallback));
+      return navigation.listen(() => {
+        setLayout(findLayout(props.paths, navigation.path, fallback));
       });
     }, []);
 


### PR DESCRIPTION
## Summary
Removes react-router coupling from `piral-page-layouts` by replacing `{ location }` destructure in `navigation.listen` with `navigation.path`, making the plugin fully router-agnostic.

## Why
The plugin destructures `{ location }` from the `navigation.listen` callback, tying it to react-router's location type shape. While `navigation.listen()` is already router-agnostic under the hood (uses Piral's `piral-navigate` DOM events), the callback parameter mirrors the history API unnecessarily.

The fix follows the same pattern already used by `piral-breadcrumbs/src/Breadcrumbs.tsx:22-23` — reading `navigation.path` directly.

## What changed
**`src/plugins/piral-page-layouts/src/utils.ts`** — 2-line change:
```diff
-      return navigation.listen(({ location }) => {
-        setLayout(findLayout(props.paths, location.pathname, fallback));
+      return navigation.listen(() => {
+        setLayout(findLayout(props.paths, navigation.path, fallback));
```

## Tests (36 new, all passing)
| File | Tests | Coverage |
|------|-------|----------|
| `utils.test.tsx` | 18 | `getPageLayouts` edge cases, `withPageLayouts` immutability, `createPageWrapper` rendering |
| `actions.test.ts` | 8 | `registerPageLayout`/`unregisterPageLayout` state mutations, immutability, round-trip |
| `create.test.ts` | 10 | Full API lifecycle: initialization, pilet ownership guards, multi-registration, disposer behavior |

```
$ npx vitest run src/plugins/piral-page-layouts/
✓ utils.test.tsx   (18 tests)
✓ actions.test.ts  (8 tests)
✓ create.test.ts   (10 tests)
Test Files  3 passed (3)
     Tests  36 passed (36)
```

## Verification
- `tsc --noEmit` — clean
- Zero remaining `navigation.listen({location})` patterns in entire `src/` directory
- Zero `from 'react-router'` imports in any plugin package
