### PR TITLE
Improve Dependency Sharing with `mf` Format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed using development condition in production dependency resolution (#868)
 - Added support for `react-router` v8
+- Improved dependency sharing with the mf pilet format
 
 ## 1.12.2 (August 5, 2026)
 

--- a/src/framework/piral-base/src/loaders/mf/index.ts
+++ b/src/framework/piral-base/src/loaders/mf/index.ts
@@ -22,23 +22,23 @@ interface MfContainer {
 }
 
 const appShell = 'piral';
+const systemRegistry = (System as any).registerRegistry as Record<string, unknown>;
+const sharedScope = { current: undefined as MfScope | undefined };
 
 function populateKnownDependencies(scope: MfScope) {
   // SystemJS to MF
-  for (const [entry] of System.entries()) {
+  for (const entry of Object.keys(systemRegistry)) {
     const index = entry.lastIndexOf('@');
 
     if (index > 0 && !entry.match(/^https?:\/\//)) {
       const entryName = entry.substring(0, index);
       const entryVersion = entry.substring(index + 1);
 
-      if (!(entryName in scope)) {
-        scope[entryName] = {};
-      }
-
-      scope[entryName][entryVersion] = {
+      scope[entryName] ??= {};
+      scope[entryName][entryVersion] ??= {
         from: appShell,
         eager: false,
+        loaded: 1,
         get: () => System.import(entry).then((result) => () => result),
       };
     }
@@ -52,10 +52,24 @@ function extractSharedDependencies(scope: MfScope) {
 
     for (const entryVersion of Object.keys(entries)) {
       const entry = entries[entryVersion];
+      const entryKey = `${entryName}@${entryVersion}`;
 
-      if (entry.from !== appShell) {
-        registerModule(`${entryName}@${entryVersion}`, () => entry.get().then((factory) => factory()));
+      if (entry.from !== appShell && !(entryKey in systemRegistry)) {
+        registerModule(entryKey, () => entry.get().then((factory) => factory()));
       }
+
+      // Flagging the scope entry as loaded ensures that subsequent pilets do not
+      // overwrite an entry already registered by an earlier pilet.
+      // We want to avoid overwrites to ensure stability.
+      //
+      // Inside a pilet bundled with the MF format, the corresponding scope
+      // registration flow is equivalent to:
+      //   if (!activeVersion || (!activeVersion.loaded && !hasEagerPrecedence)) {
+      //     writeDependencyToScope();
+      //   }
+      //
+      // -> By setting loaded to 1, we ensure that already registered entries are not overwritten.
+      entry.loaded = 1;
     }
   }
 }
@@ -63,10 +77,14 @@ function extractSharedDependencies(scope: MfScope) {
 function loadMfFactory(piletName: string, exposedName: string) {
   const varName = piletName.replace(/^@/, '').replace('/', '-').replace(/\-/g, '_');
   const container: MfContainer = window[varName];
-  const scope: MfScope = {};
-  container.init(scope);
-  populateKnownDependencies(scope);
-  extractSharedDependencies(scope);
+
+  if (!sharedScope.current) {
+    sharedScope.current = {};
+    populateKnownDependencies(sharedScope.current);
+  }
+
+  container.init(sharedScope.current);
+  extractSharedDependencies(sharedScope.current);
   return container.get(exposedName);
 }
 

--- a/src/framework/piral-base/src/types/service.ts
+++ b/src/framework/piral-base/src/types/service.ts
@@ -198,7 +198,7 @@ export interface PiletV3Entry {
 }
 
 /**
- * Metadata for pilets using the v2 schema.
+ * Metadata for pilets using the mf schema.
  */
 export interface PiletMfEntry {
   /**


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

### Description

Improves how dependencies are shared when using the `mf` pilet format. This is done by:
- introducing a single share scope used by all pilets
- adding all _registered_ (and not only imported) SystemJS dependencies with the share scope
- making sure that pilets loaded later than others do not overwrite an entry already present in the share scope

### Remarks

_None._
