### PR TITLE
Share non-root packages when using Module Federation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed resolution of bun lockfile (#869) @daniel-rck
 - Fixed issue with input stream pipe direction (#869) @daniel-rck
 - Added support for `react-router` v8
+- Share nested packages/exports of dependencies when using `piral-cli-webpack5` with the `mf` pilet format
 
 ## 1.12.2 (August 5, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@
 - Fixed using development condition in production dependency resolution (#868)
 - Fixed resolution of bun lockfile (#869) @daniel-rck
 - Fixed issue with input stream pipe direction (#869) @daniel-rck
+- Improved dependency sharing with the mf pilet format @manuelroemer
 - Added support for `react-router` v8
-- Improved dependency sharing with the mf pilet format
-- Share nested packages/exports of dependencies when using `piral-cli-webpack5` with the `mf` pilet format
+- Added full exports sharing of dependencies when using `piral-cli-webpack5` for `mf` pilets @manuelroemer
 
 ## 1.12.2 (August 5, 2026)
 

--- a/src/tooling/piral-cli-webpack5/src/enhancers/pilet-webpack-config-enhancer/helpers.ts
+++ b/src/tooling/piral-cli-webpack5/src/enhancers/pilet-webpack-config-enhancer/helpers.ts
@@ -55,7 +55,6 @@ export function getShared(importmap: Array<SharedDependency>, externals: Array<s
         eager: false,
         requiredVersion,
         version,
-        packageName: dep.name,
         singleton: false,
       };
     }

--- a/src/tooling/piral-cli-webpack5/src/enhancers/pilet-webpack-config-enhancer/helpers.ts
+++ b/src/tooling/piral-cli-webpack5/src/enhancers/pilet-webpack-config-enhancer/helpers.ts
@@ -37,12 +37,26 @@ export function getShared(importmap: Array<SharedDependency>, externals: Array<s
 
   for (const dep of importmap) {
     if (dep.type === 'local') {
+      const requiredVersion = dep.requireId.split('@').pop();
+      const version = dep.id.split('@').pop();
+
+      // This shares the root-level package (e.g., `@scope/package`).
       shared[dep.name] = {
         eager: false,
-        requiredVersion: dep.requireId.split('@').pop(),
-        version: dep.id.split('@').pop(),
+        requiredVersion,
+        version,
         packageName: dep.entry,
-        singleton: true,
+        singleton: false,
+      };
+
+      // This shares non-root exports of a package (e.g., `@scope/package/nested-export`).
+      // Ref: https://webpack.js.org/plugins/module-federation-plugin/#sharing-libraries
+      shared[dep.name + "/"] = {
+        eager: false,
+        requiredVersion,
+        version,
+        packageName: dep.name,
+        singleton: false,
       };
     }
   }


### PR DESCRIPTION
# New Pull Request

For more information, see the `CONTRIBUTING` guide.

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

### Description

This updates `piral-cli-webpack5` to share non-root exports when using the `mf` pilet format.
The personal use-case for this is to share packages like `@angular/core/rxjs-interop` in addition to the top-level pendant `@angular/core`.

### Remarks

This PR is very minimal and just configures the Modul Federation plugin to automatically share all non-root exports. I am not 100% sure if we should do that or if we should put the behavior behind a check or option.
If yes, what option/configuration should we use?